### PR TITLE
fix ids

### DIFF
--- a/app/components/deprecation-article.js
+++ b/app/components/deprecation-article.js
@@ -9,4 +9,10 @@ export default Component.extend({
   idForUntil: computed('model.until', function() {
     return `toc_until-${this.get('model.until')}`;
   }),
+  idForDeprecation: computed('model.id', function() {
+    let idString = this.get('model.id');
+    idString = idString.replace(/\s+/g, '');
+    let replacedIdString = idString.replace(/\.|,/g, '-');
+    return `toc_id-${replacedIdString}`;
+  })
 });

--- a/app/templates/components/deprecation-article.hbs
+++ b/app/templates/components/deprecation-article.hbs
@@ -1,6 +1,6 @@
-<h4 class="anchorable-toc" id={{idForTitle}}>{{model.title}}</h4>
-<h5 class="anchorable-toc" id={{idForUntil}}>until: {{model.until}}</h5>
-<h5 class="anchorable-toc">id: {{model.id}}</h5>
+<h4>{{model.title}}</h4>
+<h5>until: {{model.until}}</h5>
+<h5 class="anchorable-toc" id="{{idForDeprecation}}">id: {{model.id}}</h5>
 
 <p>
   {{markdown-to-html model.content}}

--- a/content/ember/v2/test-as-function.md
+++ b/content/ember/v2/test-as-function.md
@@ -39,7 +39,7 @@ You have 3 options to refactor second argument from `function` to `boolean`:
 
 Example:
 
-``` javascript
+```javascript
 // ... message, options omitted for brevity
 
 // passing IIFE (1)


### PR DESCRIPTION
This PR fixes the generated id 
- every . is replaced with -
- if an id is comprised of multiple comma separated entities, they will be turned into an id where each comma is replaced with a -

A small unrelated fix of a markdown file that was broken 

cc @mansona 