### PR TITLE
fix the content deprecation warning

### DIFF
--- a/app/controllers/show.js
+++ b/app/controllers/show.js
@@ -1,7 +1,9 @@
 import Controller from '@ember/controller';
 import EmberObject, { computed } from '@ember/object';
+import { alias } from '@ember/object/computed';
 
 export default Controller.extend({
+  content: alias('model'),
   init() {
     this._super(...arguments);
     this.sortDefinition = ['since'];


### PR DESCRIPTION
Using a mechanism explained in the old deprecation app to get rid of a deprecation warning in our deprecation app #meta-meta 😂 
https://emberjs.com/deprecations/v2.x/#toc_controller-content-alias