### PR TITLE
supporting more content

### DIFF
--- a/content/ember-cli/v2/migrate-from-brocfile.md
+++ b/content/ember-cli/v2/migrate-from-brocfile.md
@@ -1,0 +1,36 @@
+---
+id: cli.brocfile
+title: Migrate from Brocfile.js to ember-cli-build.js
+until: '3.0.0'
+since: '2.0.0'
+---
+
+Early versions of Ember CLI utilized the default build file of Broccoli: `Brocfile.js`. Over time
+we began realizing that this was not a tenable solution (we could not pass high fidelity objects
+into the build pipeline, and therefore created two instances of all addons, etc), and introduced a
+replacement for `Brocfile.js`: `ember-cli-build.js`.  The new structure allows Ember CLI to pass
+information into the function exported by `ember-cli-build.js` and avoid the issues mentioned above.
+
+The migration from `Brocfile.js` to `ember-cli-build.js` is fairly straight forward:
+
+Migrate `Brocfile.js` from:
+```js
+// Brocfile.js
+var EmberApp = require('ember-cli/lib/broccoli/ember-app');
+var app = new EmberApp();
+module.exports = app.toTree();
+```
+
+To `ember-cli-build.js`:
+
+```js
+var EmberApp = require('ember-cli/lib/broccoli/ember-app');
+
+module.exports = function(defaults) {
+  var app = new EmberApp(defaults, {
+      // Any options
+  });
+
+  return app.toTree();
+};
+```

--- a/content/ember-data/v2/non-primitive-default.md
+++ b/content/ember-data/v2/non-primitive-default.md
@@ -1,0 +1,27 @@
+---
+id: ds.defaultValue.complex-object
+title: Non-primitive defaultValue for Model Attributes
+until: '3.0.0'
+since: '2.3'
+---
+
+Providing a non-primitive value as a `defaultValue` has been deprecated because
+the provided value is shared between all instances of the model. Using a
+non-primitive value, such as `defaultValue: []`, can lead to unexpected bugs when
+that value is mutated.
+
+If you wish to continue using a non-primitive value as the `defaultValue` for an
+attribute, you should provide a function that returns the value:
+
+```javascript
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  username: DS.attr('string'),
+  createdAt: DS.attr('date', {
+    defaultValue() {
+      return new Date();
+    }
+  })
+});
+```

--- a/content/ember/v1/observing-container-views.md
+++ b/content/ember/v1/observing-container-views.md
@@ -1,0 +1,10 @@
+---
+id: observing-container-views-like-arrays
+title:  Observing container views like arrays
+until: ''
+since: '1.7'
+---
+
+ContainerViews have been observable as arrays, where the items in
+the array are childViews. This introduces complexity into container
+views despite the feature being a rarely used one.

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,20 +4,26 @@ const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 const StaticSiteJson = require('broccoli-static-site-json');
 const BroccoliMergeTrees = require('broccoli-merge-trees');
 
-const jsonTree = new StaticSiteJson(`content/ember/v2`, {
+const contentFolders = ['ember/v1', 'ember/v2', 'ember-data/v2', 'ember-cli/v2'];
+
+const jsonTrees = contentFolders.map((type) => new StaticSiteJson(`content/${type}`, {
   attributes: ['title', 'since', 'until'],
   type: 'contents',
   collections: [{
-    src: 'content/ember/v2',
-    output: 'ember-v2.x.json',
-  }]
-});
+    src: `content/${type}`,
+    output: `${type.replace(/\//, '-')}.x.json`,
+  }
+]
+}));
 
 let urls = [];
 
 if (!process.env.JSON_ONLY) {
   urls = [
-    '/ember/v2.x'
+    '/ember/v2.x',
+    '/ember/v1.x',
+    '/ember-data/v2.x',
+    '/ember-cli/v2.x'
   ];
 }
 
@@ -32,19 +38,5 @@ module.exports = function(defaults) {
       'plugins': ['line-numbers', 'normalize-whitespace']
     }
   });
-
-  // Use `app.import` to add additional libraries to the generated
-  // output files.
-  //
-  // If you need to use different assets in different
-  // environments, specify an object as the first parameter. That
-  // object's keys should be the environment name and the values
-  // should be the asset to use in that environment.
-  //
-  // If the library that you are including contains AMD or ES6
-  // modules that you would like to import into your application
-  // please specify an object with the list of modules as keys
-  // along with the exports of each module as its value.
-
-  return new BroccoliMergeTrees([app.toTree(), jsonTree]);
+  return new BroccoliMergeTrees([app.toTree(), ...jsonTrees]);
 };


### PR DESCRIPTION
This PR allows us to support multiple contents, such as ember-data, ember-cli and the various versions of ember

Please note that i only added an example deprecation for this Pr for each of the different versions. Will follow up with adding the actual content, once all these are supported. 
cc @mansona happy to chat through the changes and make improvements. Also i have no idea how the netlify setup works, its failing right now :(