### PR TITLE
Add missing section

### DIFF
--- a/content/ember/v1/ember-reduce-computed-property.md
+++ b/content/ember/v1/ember-reduce-computed-property.md
@@ -1,5 +1,5 @@
 ---
-id: ember-reducecomputed-ember-arraycomputed
+id: ember-reducecomputedproperty-ember-arraycomputedproperty
 title: Ember.ReduceComputedProperty / Ember.ArrayComputedProperty
 until: ''
 since: '1.13'

--- a/content/ember/v1/ember-reduce-computed.md
+++ b/content/ember/v1/ember-reduce-computed.md
@@ -1,0 +1,12 @@
+---
+id: ember-reducecomputed-ember-arraycomputed
+title: Ember.ReduceComputed / Ember.ArrayComputed
+until: ''
+since: '1.13'
+---
+
+These two little monsters served us well for a long time. They provided semantics that allowed to perform in-place modifications of an existing array instead of replacing the entire array like the regular `map/reduce` methods in javascript do, which was necessary to avoid expensive repaintings when rendering lists with the `{{each}}` helper.
+
+But now that with the new glimmer engine you can generate a entirely new array and let glimmer handle the diffing for you they've become an unnecessary and overcomplicated abstraction that adds no value over the native counterparts.
+
+They will be extracted as an ember addon in case you need to keep using them, but the recommendation now is to just use the native array methods or those in libraries like Underscore/Lodash.


### PR DESCRIPTION
Part of https://github.com/ember-learn/deprecation-app/issues/69 cc @serenaf 

`Ember.ReduceComputed / Ember.ArrayComputed` from https://www.emberjs.com/deprecations/v1.x/#toc_ember-reducecomputed-ember-arraycomputed was missing.

Could be ok to merge as-is, but have questions if you care about these nits:

I set the `id`'s to be the same as the current website. But this makes `Ember.ReduceComputed / Ember.ArrayComputed` appear below `Ember.ReduceComputedProperty / Ember.ArrayComputedProperty`. 

Does the `id` naming matter? 

Where can I learn more about how the `id`'s are sorted? (Still getting familiar with the repo!) 