### PR TITLE
v1 tweaks miscellaneous

### DIFF
--- a/content/ember/v1/controller-needs.md
+++ b/content/ember/v1/controller-needs.md
@@ -5,7 +5,7 @@ until: ''
 since: '1.13'
 ---
 
-`needs` for controllers will be removed in Ember 2.0. You can migrate away from this using `Ember.inject.controller`
+`needs` for controllers will be removed in Ember 2.0. You can migrate away from this using `Ember.inject.controller`.
 
 Lets say you have a `post` controller like this:
 
@@ -29,4 +29,4 @@ export default Ember.Controller.extend({
 });
 ```
 
-You can [read more about `Ember.inject.controller` in the Ember API documentation](http://emberjs.com/api/classes/Ember.inject.html#method_controller)
+You can [read more about Ember.inject.controller in the Ember API documentation](http://emberjs.com/api/classes/Ember.inject.html#method_controller).

--- a/content/ember/v1/copyable-frozen-copy.md
+++ b/content/ember/v1/copyable-frozen-copy.md
@@ -7,7 +7,7 @@ since: '1.13'
 
 Just as the `Freezable` mixin is deprecated in favor of functionality in
 core JavaScript, the `frozenCopy` method of the Copyable mixin is also
-deprecated in favor of [`Object.freeze()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze).
+deprecated in favor of [Object.freeze()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze).
 
 Replace the following code:
 

--- a/content/ember/v1/handlebars.md
+++ b/content/ember/v1/handlebars.md
@@ -7,8 +7,8 @@ since: '1.13'
 
 All the various ways to create helpers on the Handlebars and HTMLBars namespace
 have been deprecated in favor of the
-[`Ember.Helper`](http://emberjs.com/api/classes/Ember.Helper.html) class and it's
-[`Ember.Helper.helper`](http://emberjs.com/api/classes/Ember.Helper.html#method_helper)
+[Ember.Helper](http://emberjs.com/api/classes/Ember.Helper.html) class and it's
+[Ember.Helper.helper](http://emberjs.com/api/classes/Ember.Helper.html#method_helper)
 function. The `makeViewHelper` method has been deprecated in favor of just using
 an `Ember.Component`.
 

--- a/content/ember/v1/sortable-mixin.md
+++ b/content/ember/v1/sortable-mixin.md
@@ -31,6 +31,6 @@ const SongsController = Ember.Controller.extend({
 let songsController = SongsController.create({ songs: songList });
 ```
 
-You can [read more about `Ember.computed.sort` in the Ember API documentation](http://emberjs.com/api/classes/Ember.computed.html#method_sort)
+You can [read more about Ember.computed.sort in the Ember API documentation](http://emberjs.com/api/classes/Ember.computed.html#method_sort)
 
 Legacy support of `Ember.SortableMixin` will be provided via the [ember-legacy-controllers](https://github.com/emberjs/ember-legacy-controllers) addon.

--- a/content/ember/v1/using-the-with-helper.md
+++ b/content/ember/v1/using-the-with-helper.md
@@ -18,7 +18,7 @@ specified controller as the context within the block.
 ```
 
 Similar to the
-[deprecated `{{each}}` helper controller options](http://emberjs.com/deprecations/v1.x#toc_view-and-controller-options-on-the-code-each-code-helper)
+[deprecated {{each}} helper controller options](http://emberjs.com/deprecations/v1.x#toc_view-and-controller-options-on-the-code-each-code-helper)
 , this approach triggers less performant compatibility code and is deprecated in
 favor of using local properties or components.
 

--- a/content/ember/v1/using-this-get-template.md
+++ b/content/ember/v1/using-this-get-template.md
@@ -6,12 +6,12 @@ since: '1.13'
 ---
 
 Prior to 1.13, developers had to check for the existance of the internal `template` property to determine the existance of a yielded block.
-This is being deprecated in favor of using the new [`hasBlock`](http://emberjs.com/api/classes/Ember.Component.html#property_hasBlock)
+This is being deprecated in favor of using the new [hasBlock](http://emberjs.com/api/classes/Ember.Component.html#property_hasBlock)
 property within your templates.
 
 ##### Determining if a block has been provided from JavaScript
 
 Currently the `hasBlock` property is not made available from the JavaScript component object,
 so there is no clean alternative for checking whether a block has been passed.
-See the [JavaScript `hasBlock` RFC](https://github.com/emberjs/rfcs/pull/102) for discussion on making this information
+See the [JavaScript hasBlock RFC](https://github.com/emberjs/rfcs/pull/102) for discussion on making this information
 available in the future, as well as possible workarounds.


### PR DESCRIPTION
Part of #69 cc @serenaf

(1) Remove backticks from markdown links for better styling

(If you like this change, and have ideas on how to enforce this programmatically, let me know!)

IS:
![image](https://user-images.githubusercontent.com/1372946/36465842-fbfaec5e-168b-11e8-8bd9-e3bb9be071ba.png)

WAS:
![image](https://user-images.githubusercontent.com/1372946/36465849-0347651e-168c-11e8-8ac6-f48246c4cba9.png)

(2) Fix typos

Note: This is the last of v1 stuff from me re: #69!