### PR TITLE
Put `code` backtick back in titles

### DIFF
--- a/content/ember/v1/non-standard-ways.md
+++ b/content/ember/v1/non-standard-ways.md
@@ -1,6 +1,6 @@
 ---
 id: non-standard-ways-of-calling-code-ember-set-code-and-code-ember-get-code
-title: Non-Standard Ways of Calling Ember.set and Ember.get
+title: Non-Standard Ways of Calling `Ember.set` and `Ember.get`
 until: ''
 since: '1.13'
 ---

--- a/content/ember/v1/overriding-render.md
+++ b/content/ember/v1/overriding-render.md
@@ -1,6 +1,6 @@
 ---
 id: overriding-code-render-code-when-extending-a-component-or-view
-title: Overriding render When Extending a Component or View
+title: Overriding `render` When Extending a Component or View.
 until: ''
 since: '1.13'
 ---

--- a/content/ember/v1/overriding-render.md
+++ b/content/ember/v1/overriding-render.md
@@ -1,6 +1,6 @@
 ---
 id: overriding-code-render-code-when-extending-a-component-or-view
-title: Overriding `render` When Extending a Component or View.
+title: Overriding `render` When Extending a Component or View
 until: ''
 since: '1.13'
 ---

--- a/content/ember/v1/using-each-as-leafnode.md
+++ b/content/ember/v1/using-each-as-leafnode.md
@@ -1,6 +1,6 @@
 ---
 id: using-code-each-code-as-a-leaf-node-in-a-dependent-key
-title: Using @each as a leaf node in a dependent key
+title: Using `@each` as a leaf node in a dependent key
 until: ''
 since: '1.13'
 ---

--- a/content/ember/v1/using-slash-for-namespace.md
+++ b/content/ember/v1/using-slash-for-namespace.md
@@ -1,6 +1,6 @@
 ---
 id: using-code-code-for-namespace-in-the-code-render-code-helper
-title:  Using / for namespace in the {{render}} helper
+title:  Using `/` for namespace in the `{{render}}` helper
 until: ''
 since: '1.13'
 ---

--- a/content/ember/v1/using-the-with-helper.md
+++ b/content/ember/v1/using-the-with-helper.md
@@ -1,6 +1,6 @@
 ---
 id: using-the-code-with-code-helper-with-the-code-controller-code-option
-title: Using the {{with}} Helper with the controller option
+title: Using the `{{with}}` Helper with the `controller` option
 until: ''
 since: '1.13'
 ---

--- a/content/ember/v1/using-this-get-template.md
+++ b/content/ember/v1/using-this-get-template.md
@@ -1,6 +1,6 @@
 ---
 id: using-code-this-get-template-code
-title: Using this.get('template')
+title: Using `this.get('template')`
 until: ''
 since: '1.13'
 ---

--- a/content/ember/v1/using-tracked-array.md
+++ b/content/ember/v1/using-tracked-array.md
@@ -1,6 +1,6 @@
 ---
 id: using-code-trackedarray-code-or-code-subarray-code
-title: Using TrackedArray or SubArray
+title: Using `TrackedArray` or `SubArray`
 until: ''
 since: '1.13'
 ---

--- a/content/ember/v1/views-and-controller-options.md
+++ b/content/ember/v1/views-and-controller-options.md
@@ -1,6 +1,6 @@
 ---
 id: view-and-controller-options-on-the-code-each-code-helper
-title: View and Controller options on the {{each}} helper
+title: View and Controller options on the `{{each}}` helper
 until: ''
 since: '1.13'
 ---
@@ -50,3 +50,5 @@ component.
 
 We replaced `tagName="ul"` part by just surrounding the `{{each}}` block with
 `<ul>` tags.
+
+


### PR DESCRIPTION
* Revert "Cleanup titles". This reverts commit c3e7677 from https://github.com/ember-learn/deprecation-app/pull/86. We need to preserve the word `code` in the id, so it is confusing to remove the backtick from the title. Relates to https://github.com/ember-learn/deprecation-app/issues/95.

This keeps the `id` and `title` matching, example below:
```
id: overriding-code-render-code-when-extending-a-component-or-view
title: Overriding `render` When Extending a Component or View
```

* Fix unnecessary period in `title` (did not match other titles without a period).

