### PR TITLE
[WIP] making the html structure better

### DIFF
--- a/app/templates/components/deprecation-article.hbs
+++ b/app/templates/components/deprecation-article.hbs
@@ -1,9 +1,9 @@
-<h4 class="anchorable-toc" id="{{id-for-deprecation model.id}}">{{model.title}}</h4>
+<h3 class="anchorable-toc" id="{{id-for-deprecation model.id}}">{{model.title}}</h3>
 {{#if renderIdOrUntil}}
-  <h5>until: {{model.until}}</h5>
+  <h4>until: {{model.until}}</h4>
 {{/if}}
 {{#if renderIdOrUntil}}
-  <h5>id: {{model.id}}</h5>
+  <h4>id: {{model.id}}</h4>
 {{/if}}
 <p>
   {{markdown-to-html model.content}}

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -1,22 +1,22 @@
 <div id="content" class="main" role="main">
-  <h2 class="anchorable-toc" id="toc_deprecations">Deprecations</h2>
+  <h1 class="anchorable-toc" id="toc_deprecations">Deprecations</h1>
   <p>Periodically, various APIs in Ember.js may be deprecated. During a minor
   release, for instance when upgrading from version 1.9 to 1.10, you may see new
   deprecations fire in your codebase. Until a major revision such as 2.0 lands,
   code firing such deprecations is still supported by the Ember community. After
   the next major revision lands, the supporting code may be removed. This style
   of change management is commonly referred to as <a href="http://semver.org/">Semantic Versioning</a>.</p>
-  <h3 class="anchorable-toc" id="toc_ember">Ember</h3>
+  <h2 class="anchorable-toc" id="toc_ember">Ember</h2>
   <ul>
     <li>{{#link-to 'ember' 'v1.x'}}Version 1.x{{/link-to}}</li>
     <li>{{#link-to 'ember' 'v2.x'}}Version 2.x{{/link-to}}</li>
     <li>{{#link-to 'ember' 'v3.x'}}Version 3.x{{/link-to}}</li>
   </ul>
-  <h3 class="anchorable-toc" id="toc_ember-data">Ember Data</h3>
+  <h2 class="anchorable-toc" id="toc_ember-data">Ember Data</h2>
   <ul>
     <li>{{#link-to 'show' 'ember-data' 'v2.x'}}Version 2.x{{/link-to}}</li>
   </ul>
-  <h3 class="anchorable-toc" id="toc_ember-cli">Ember CLI</h3>
+  <h2 class="anchorable-toc" id="toc_ember-cli">Ember CLI</h2>
   <ul>
     <li>{{#link-to 'show' 'ember-cli' 'v2.x'}}Version 2.x{{/link-to}}</li>
   </ul>

--- a/app/templates/show.hbs
+++ b/app/templates/show.hbs
@@ -4,13 +4,13 @@
 </div>
 
 <div class="main has-sidebar" id="content" role="main">
-  <h2>Deprecations Added in {{project}} {{version}}</h2>
+  <h1>Deprecations Added in {{project}} {{version}}</h1>
   <p>What follows is a list of deprecations introduced to {{project}} during the {{version}}
   cycle.</p>
   <p>For more information on deprecations in {{project}}, see the {{#link-to 'index'}}main deprecations page{{/link-to}}.</p>
 
   {{#each sortedGroupedResults as |result|}}
-    <h3 class="anchorable-toc">Deprecations Added in {{result.since}} </h3>
+    <h2 class="anchorable-toc">Deprecations Added in {{result.since}} </h2>
       {{renderId}}
       {{#each result.contents as |content|}}
         {{deprecation-article model=content renderIdOrUntil=renderIdOrUntil}}


### PR DESCRIPTION
This PR is a work in progress in making the HTML structure of the deprecations app more sane :)

@MelSumner Could you have a look with me what should be done here? Right now it ads a border-bottom to the h1 element, because of below rule. Can i override this rule? 

<img width="886" alt="screen shot 2018-03-12 at 10 07 29" src="https://user-images.githubusercontent.com/1288131/37298640-106faefc-25de-11e8-9655-0d4d90176b81.png">
<img width="692" alt="screen shot 2018-03-12 at 10 07 22" src="https://user-images.githubusercontent.com/1288131/37298641-109f3208-25de-11e8-9c3f-3ddfd9a0a117.png">
