### PR TITLE
Remove text that suggests to upgrade ember-cli version to see deprecation messages

### DIFF
--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -6,20 +6,18 @@
   code firing such deprecations is still supported by the Ember community. After
   the next major revision lands, the supporting code may be removed. This style
   of change management is commonly referred to as <a href="http://semver.org/">Semantic Versioning</a>.</p>
-  
+
   <p>
-    <a href="https://github.com/ember-cli/ember-cli/releases">Upgrade your ember-cli version</a> 
-    to see which deprecations affect your app, when they are scheduled to change, 
-    and how to fix them. You can use newer versions of the CLI with older Ember apps. 
-    It's a good idea to resolve deprecations as they arise so that when a major 
-    version is available, it's easier to upgrade your app. For some significant changes,
-    codemods may be available, so check out 
+    You can use newer versions of the CLI with older Ember apps. It's a good
+    idea to resolve deprecations as they arise so that when a major version is
+    available, it's easier to upgrade your app. For some significant changes,
+    codemods may be available, so check out
     <a href="https://emberjs.com/blog/">
       Release Blog Posts
-    </a> 
+    </a>
     before you dive in.
   </p>
-  
+
   <h3 class="anchorable-toc" id="toc_ember">Ember</h3>
   <ul>
     <li>{{#link-to 'ember' 'v1.x'}}Version 1.x{{/link-to}}</li>


### PR DESCRIPTION
See Issue #113 