### PR TITLE
Consistent scale and spacing of Tomster illustrations

### DIFF
--- a/app/styles/_ember-version-graphic.scss
+++ b/app/styles/_ember-version-graphic.scss
@@ -10,8 +10,8 @@
 
   $container-background-color: $ember-orange-color;
   $container-border-radius: 4px;
-  $container-height: 250px;
-  $container-width: floor($container-height / 1.77);
+  $container-height: 230px;
+  $container-width: floor($container-height / 1.6);
   $text-color: $white-color;
   $text-font-size: 72px;
   $text-shadow-color: darken($container-background-color, 100%);
@@ -31,11 +31,21 @@
     }
   }
 
+  &.tomster-deprecated { background-position-x: 12px; }
+
   .text {
     line-height: 0.8;
     color: $text-color;
     font-size: $text-font-size;
     font-weight: bold;
     text-shadow: 3px 3px 0 $text-shadow-color, -1px -1px 0 $text-shadow-color, 1px -1px 0 $text-shadow-color, -1px 1px 0 $text-shadow-color, 1px 1px 0 $text-shadow-color;
+  }
+}
+
+@media screen and (min-width: 710px) {
+  .ember-version-graphic {
+    &.tomster-lts { background-size: 81%; }
+    &.zoey { background-size: 76%; }
+    &.tomster-deprecated { background-position: 6px 16px; }
   }
 }

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -5044,6 +5044,7 @@ body.tomster_faq #subcontent #back-to-top {
     margin: $spacing;
     padding: 0;
     border: 1px solid $ember-orange-color;
+    border-radius: 3px;
 
     .links {
       min-width: 120px;


### PR DESCRIPTION
Original:

<img width="650" alt="screen shot 2018-05-01 at 6 42 29 pm" src="https://user-images.githubusercontent.com/3692/39501477-f489abde-4d6f-11e8-9509-9a145453bd6f.png">

Proposal:

<img width="655" alt="screen shot 2018-05-01 at 6 40 50 pm" src="https://user-images.githubusercontent.com/3692/39501486-01d78eaa-4d70-11e8-903b-2154d2fbabaa.png">

The images being used from emberjs.com are a different size. I scaled them with CSS but we could also copy them to this repo and scale in Photoshop. Thoughts?