### PR TITLE
Fix ID of "Getting the @each property" deprecation

### DIFF
--- a/content/ember/v3/getting-each.md
+++ b/content/ember/v3/getting-each.md
@@ -1,5 +1,5 @@
 ---
-id: getting-the-each-property
+id: ember-metal.getting-each
 title: Getting the @each property
 until: '3.5.0'
 since: '3.1'


### PR DESCRIPTION
The correct ID can be found here: https://github.com/emberjs/ember.js/blob/c2c8171301d2b1a0c499b4a55009ebf428f40e69/packages/%40ember/-internals/runtime/lib/mixins/array.js#L1159