### PR TITLE
Fix `since` for setComponentManager deprecation

### DIFF
--- a/content/ember/v3/deprecate-string-based-component-manager-lookup.md
+++ b/content/ember/v3/deprecate-string-based-component-manager-lookup.md
@@ -2,7 +2,7 @@
 id: component-manager-string-lookup
 title: Component Manager Factory Function
 until: '4.0.0'
-since: '3.8.0'
+since: '3.8'
 ---
 
 `setComponentManager` no longer takes a string to associate the custom component class and the component manager. Instead you must pass a factory function that produces an instance of the component manager.


### PR DESCRIPTION
The rest of the deprecations are just `<Major>.<Minor>` (don't include patch version). This one as `3.8.0` leads to two different entries in the sidebar for 3.8 (one for 3.8 and one for 3.8.0).