### PR TITLE
fix: update grammar `underneath is` -> `underneath it is`

### DIFF
--- a/content/ember/v3/send-action.md
+++ b/content/ember/v3/send-action.md
@@ -101,7 +101,7 @@ strings:
 {{input enter="handleEnter"}}
 ```
 
-Since this uses `sendAction` underneath is also deprecated and must also be replaced by closure actions:
+Since this uses `sendAction` underneath it is also deprecated and must also be replaced by closure actions:
 
 ```hbs
 {{input enter=(action "handleEnter")}}


### PR DESCRIPTION
fix: update grammar `underneath is` -> `underneath it is`