### PR TITLE
only suggest using currentRouteName

### DIFF
--- a/content/ember/v3/application-controller-router-properties.md
+++ b/content/ember/v3/application-controller-router-properties.md
@@ -7,7 +7,7 @@ since: '3.10'
 
 If you are reliant on the `currentPath` and `currentRouteName` properties of the `ApplicationController`, you can get the same functionality from the `Router` service.
 
-To migrate, inject the `Router` service and read the `currentRouteName` or `currentPath` off of it.
+To migrate, inject the `Router` service and read the `currentRouteName` off of it.
 
 Before:
 


### PR DESCRIPTION
I removed the advice to use `currentPath` from the Router service because it does not have a public `currentPath` property:
https://api.emberjs.com/ember/3.10/classes/RouterService