### PR TITLE
Show ember-data v3.x deprecations

### DIFF
--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -42,6 +42,7 @@
       {{ember-version-graphic mascot='zoey' text='3.x'}}
       <ul class="links">
         <li>{{#link-to 'ember' 'v3.x'}}Ember{{/link-to}}</li>
+        <li>{{#link-to 'show' 'ember-data' 'v3.x'}}Ember Data{{/link-to}}</li>
       </ul>
     </li>
   </ul>

--- a/lib/content-docs-generator/index.js
+++ b/lib/content-docs-generator/index.js
@@ -3,16 +3,28 @@
 const StaticSiteJson = require('broccoli-static-site-json');
 const BroccoliMergeTrees = require('broccoli-merge-trees');
 
-const contentFolders = ['ember/v1', 'ember/v2', 'ember/v3', 'ember-data/v2', 'ember-cli/v2'];
+const contentFolders = [
+  'ember/v1',
+  'ember/v2',
+  'ember/v3',
+  'ember-data/v2',
+  'ember-data/v3',
+  'ember-cli/v2'
+];
 
-const jsonTrees = contentFolders.map((type) => new StaticSiteJson(`content/${type}`, {
-  attributes: ['title', 'since', 'until'],
-  type: 'contents',
-  collections: [{
-    src: `content/${type}`,
-    output: `${type.replace(/\//, '-')}.x.json`,
-  }]
-}));
+const jsonTrees = contentFolders.map(
+  (type) =>
+    new StaticSiteJson(`content/${type}`, {
+      attributes: ['title', 'since', 'until'],
+      type: 'contents',
+      collections: [
+        {
+          src: `content/${type}`,
+          output: `${type.replace(/\//, '-')}.x.json`
+        }
+      ]
+    })
+);
 
 module.exports = {
   name: 'content-docs-generator',
@@ -22,7 +34,6 @@ module.exports = {
   },
 
   treeForPublic() {
-    return new BroccoliMergeTrees([...jsonTrees])
+    return new BroccoliMergeTrees([...jsonTrees]);
   }
 };
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -12046,7 +12046,6 @@
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -12242,8 +12241,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -12333,8 +12331,7 @@
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },


### PR DESCRIPTION
#413 isn't caused by deployment failures. The deprecations didn't show up since the new folder wasn't added to the content generator. This PR fixes it.


fixes #413 