### PR TITLE
Fix the example in router-events.md

### DIFF
--- a/content/ember/v3/router-events.md
+++ b/content/ember/v3/router-events.md
@@ -45,18 +45,19 @@ import Router from '@ember/routing/router';
 import { inject as service } from '@ember/service';
 
 export default Router.extend({
+  router: service(),
   currentUser: service('current-user'),
 
   init() {
     this._super(...arguments);
-    this.on('routeWillChange', transition => {
+    this.router.on('routeWillChange', transition => {
       if (!this.currentUser.isLoggedIn) {
         transition.abort();
         this.transitionTo('login');
       }
     });
 
-    this.on('routeDidChange', transition => {
+    this.router.on('routeDidChange', transition => {
       ga.send('pageView', {
         pageName: transition.to.name
       });


### PR DESCRIPTION
This PR resolves issue #533 - it addresses the incorrect documentation example in [router-events.md](https://github.com/ember-learn/deprecation-app/blob/master/content/ember/v3/router-events.md).