### PR TITLE
Simplify default serializer deprecation docs

### DIFF
--- a/content/ember-data/v3/default-serializer.md
+++ b/content/ember-data/v3/default-serializer.md
@@ -27,19 +27,22 @@ application serializer to match.
 For example, if you use only JSONAPI adapters, creating the following application serializer
 will resolve the deprecation:
 
-```javascript {data-filename=app/serializers/application.js
+```javascript {data-filename=app/serializers/application.js}
+import DS from 'ember-data';
 
-export { default } from '@ember-data/serializer/json-api';
+export default DS.JSONAPISerializer.extend({
+  /*custom code*/
+});
 ```
 
-If your app uses different adapter types for different models, you should make one serializer for each model type. For example, if a certain model uses the `RESTAdapter`, create an `app/serializers/[model-type].js` file with the following:
+If your app uses different adapter types for different models, you should make one serializer for each model type. For example, if a certain model uses the `RESTAdapter`, create an `app/serializers/user.js` file with the following:
 
-```js
-    import RESTSerializer from '@ember-data/serializer/rest';
+```javascript {data-filename=app/serializers/user.js}
+import RESTSerializer from '@ember-data/serializer/rest';
 
-    export default class UserSerializer extends RESTSerializer {
-      /*custom code*/
-    }
+export default RESTSerializer.extend({
+  /*custom code*/
+});
 ```
 
-More information about custom serializers can be found in the [Serializer API Docs](https://api.emberjs.com/ember-data/release/modules/@ember-data%2Fserializer) or on the [ember.js/guides](https://guides.emberjs.com/release/models/customizing-serializers/#toc_customizing-serializers)
+More information about custom serializers can be found in the [Serializer API Docs](https://api.emberjs.com/ember-data/release/modules/@ember-data%2Fserializer) or in the [official guides](https://guides.emberjs.com/release/models/customizing-serializers/#toc_customizing-serializers).

--- a/content/ember-data/v3/default-serializer.md
+++ b/content/ember-data/v3/default-serializer.md
@@ -8,7 +8,9 @@ since: '3.12.0'
 
 ##### deprecate adapter.defaultSerializer fallback
 
-Previously, if no application or type-specific serializer was specified, the store would attempt to lookup a serializer via the `defaultSerializer` property on the type's adapter. This behavior is deprecated in favor of explicitly defining a type-specific serializer or application serializer.
+Moving forward, every app or addon that uses Ember Data must have a serializer explicitly defined.
+
+Previously, if no application or model-type-specific serializer was specified, the store would attempt to lookup a serializer via the `defaultSerializer` property on the type's adapter. This behavior is deprecated in favor of explicitly defining a type-specific serializer or application serializer.
 
 You may be relying on the `defaultSerializer` property set by the `Adapter`, `RESTAdapter` or `JSONAPIAdapter` classes.
 These classes specified the following `defaultSerializer`
@@ -17,21 +19,21 @@ These classes specified the following `defaultSerializer`
 - `RESTAdapter`: `-rest` (`@ember-data/serializer/rest`)
 - `JSONAPIAdapter`: `-json-api` (`@ember-data/serializer/json-api`)
 
-If a per-type adapter exists for the modelName triggering this deprecation, the easiest resolution is to add a per-type serializer.
+### Clearing these deprecations
 
-If the application adapter is triggering this deprecation, then an application serializer should be added.
+If all the adapters in your app are the same kind (such as JSONAPI, REST, or JSON), you should create an
+application serializer to match.
 
-More information on adding these serializers can be found in "clearing these deprecations" below.
+For example, if you use only JSONAPI adapters, creating the file below in `app/serializers/application.js`
+will resolve the deprecation:
 
-##### -default serializer fallback in store.serializerFor
+```javascript
+// app/serializers/application.js
 
-Previously, when no type-specific serializer, application serializer, or adapter defaultSerializer had been defined by the app, the `-default` serializer would be used which defaulted to the `JSONSerializer`. This behavior is deprecated in favor of explicitly defining an application or type-specific serializer as described below.
+export { default } from '@ember-data/serializer/json-api';
+```
 
-##### clearing these deprecations
-
-More information about custom serializers can be found in the [Serializer API Docs](https://api.emberjs.com/ember-data/release/modules/@ember-data%2Fserializer) or on the [ember.js/guides](https://guides.emberjs.com/release/models/customizing-serializers/#toc_customizing-serializers)
-
-If a specific model type requires custom serialization, a type-specific serializer can be created. A single `application` serializer can be used for any model types not requiring custom serialization. To define a type-specific serializer, create an `app/serializers/[type].js` with the following:
+If your app uses different adapter types for different models, you should make one serializer for each model type. For example, if a certain model uses the `RESTAdapter`, create an `app/serializers/[model-type].js` file with the following:
 
 ```js
     import RESTSerializer from '@ember-data/serializer/rest';
@@ -41,8 +43,4 @@ If a specific model type requires custom serialization, a type-specific serializ
     }
 ```
 
-Defining a serializer for the entire application can be done by adding the file `app/serializers/application.js` with the following:
-
-```js
-    export { default } from '@ember-data/serializer/json-api';
-```
+More information about custom serializers can be found in the [Serializer API Docs](https://api.emberjs.com/ember-data/release/modules/@ember-data%2Fserializer) or on the [ember.js/guides](https://guides.emberjs.com/release/models/customizing-serializers/#toc_customizing-serializers)

--- a/content/ember-data/v3/default-serializer.md
+++ b/content/ember-data/v3/default-serializer.md
@@ -24,7 +24,7 @@ These classes specified the following `defaultSerializer`
 If all the adapters in your app are the same kind (such as JSONAPI, REST, or JSON), you should create an
 application serializer to match.
 
-For example, if you use only JSONAPI adapters, creating the file below in `app/serializers/application.js`
+For example, if you use only JSONAPI adapters, creating the following application serializer
 will resolve the deprecation:
 
 ```javascript {data-filename=app/serializers/application.js

--- a/content/ember-data/v3/default-serializer.md
+++ b/content/ember-data/v3/default-serializer.md
@@ -6,7 +6,7 @@ since: '3.12.0'
 ---
 #### Default serializer deprecations
 
-##### deprecate adapter.defaultSerializer fallback
+### Deprecate adapter.defaultSerializer fallback
 
 Moving forward, every app or addon that uses Ember Data must have a serializer explicitly defined.
 

--- a/content/ember-data/v3/default-serializer.md
+++ b/content/ember-data/v3/default-serializer.md
@@ -10,7 +10,7 @@ since: '3.12.0'
 
 Moving forward, every app or addon that uses Ember Data must have a serializer explicitly defined.
 
-Previously, if no application or model-type-specific serializer was specified, the store would attempt to lookup a serializer via the `defaultSerializer` property on the type's adapter. This behavior is deprecated in favor of explicitly defining a type-specific serializer or application serializer.
+Previously, if no application or model-type-specific serializer was specified, the store would attempt to look up a serializer via the `defaultSerializer` property on the type's adapter. This behavior is deprecated in favor of explicitly defining a model-type-specific serializer or application serializer.
 
 You may be relying on the `defaultSerializer` property set by the `Adapter`, `RESTAdapter` or `JSONAPIAdapter` classes.
 These classes specified the following `defaultSerializer`

--- a/content/ember-data/v3/default-serializer.md
+++ b/content/ember-data/v3/default-serializer.md
@@ -27,8 +27,7 @@ application serializer to match.
 For example, if you use only JSONAPI adapters, creating the file below in `app/serializers/application.js`
 will resolve the deprecation:
 
-```javascript
-// app/serializers/application.js
+```javascript {data-filename=app/serializers/application.js
 
 export { default } from '@ember-data/serializer/json-api';
 ```

--- a/content/ember-data/v3/default-serializer.md
+++ b/content/ember-data/v3/default-serializer.md
@@ -6,7 +6,7 @@ since: '3.12.0'
 ---
 #### Default serializer deprecations
 
-### Deprecate adapter.defaultSerializer fallback
+#### Deprecate adapter.defaultSerializer fallback
 
 Moving forward, every app or addon that uses Ember Data must have a serializer explicitly defined.
 
@@ -19,7 +19,7 @@ These classes specified the following `defaultSerializer`
 - `RESTAdapter`: `-rest` (`@ember-data/serializer/rest`)
 - `JSONAPIAdapter`: `-json-api` (`@ember-data/serializer/json-api`)
 
-### Clearing these deprecations
+#### Clearing these deprecations
 
 If all the adapters in your app are the same kind (such as JSONAPI, REST, or JSON), you should create an
 application serializer to match.


### PR DESCRIPTION
I found this section a little bit difficult to understand. I rearranged the explanation and simplified some of the language.