### PR TITLE
Rewrite EmberComponent#isVisible guide with three alternatives

### DIFF
--- a/content/ember/v3/component-is-visible.md
+++ b/content/ember/v3/component-is-visible.md
@@ -11,6 +11,8 @@ One of them is `isVisible`, which controls if the component is hidden to the end
 
 You can update your component in one of two ways, you can wrap your component's template in an `{{if}}`, or you can use the [`hidden`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden) HTML attribute.
 
+It's worth noting that not all visibility approaches are equal- we recommend reviewing use of `aria-hidden` as well as accessible ways to visibly hide content while still making it available to assistive technology. 
+
 Because classic components have a wrapper `div` element by default,
 it might be necessary that you do additional changes to your component so that no content is accidentally shown.
 

--- a/content/ember/v3/component-is-visible.md
+++ b/content/ember/v3/component-is-visible.md
@@ -5,60 +5,124 @@ until: '4.0.0'
 since: '3.15'
 ---
 
-In ember earlier versions, we had the concept of 'A controller should never call method or change property on its associated view '( Ember.View class)', instead the view should bind the state of its associated controller.'
+Classic components have a number of APIs to handle the wrapper `div` that they create by default.
+One of them is `isVisible`, which controls if the component is hidden to the end user or not.
+`isVisible` is now deprecated in accordance with [RFC #324](https://github.com/emberjs/rfcs/blob/master/text/0324-deprecate-component-isvisible.md).
 
-So, we were using something like this,
+You can update your component in one of two ways, you can wrap your component's template in an `{{if}}`, or you can use the [`hidden`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden) HTML attribute.
 
-```js
-import Ember from 'ember';
-App.MyView = Ember.View.extend({
-  isVisible: Ember.computed.alias('controller.myViewVisible')
-}
-```
+Because classic components have a wrapper `div` element by default,
+it might be necessary that you do additional changes to your component so that no content is accidentally shown.
 
-or in the component
+Let's say you have a flash message component that hides itself when you dismiss it:
 
-```js
+```js {data-filename=app/components/flash-message.js}
 import Component from '@ember/component';
-import { alias } from '@ember/object/computed';
+
 export default Component.extend({
-  isVisible: alias('myViewVisible');
+  isVisible: true,
+
+  dismissMessage() {
+    this.set('isVisible', false);
+  }
 });
 ```
 
-We are deprecating usage of the `isVisible` in classic components in accordance with [RFC #324](https://github.com/emberjs/rfcs/blob/master/text/0324-deprecate-component-isvisible.md).
+```handlebars {data-filename=app/components/flash-message.hbs}
+<p>You received a message: "{{@message}}"</p>
 
-Instead of setting the `isVisible` property on classic components, consider either using `{{#if}}` helper like below
+<button type="button" {{action 'dismissMessage'}}>Dismiss</button>
+```
 
-```js {data-filename=app/templates/components/my-question.js}
+#### Wrapping template in an `{{if}}`
+
+Fist, let's use a different property to keep track of visibility.
+I decided to call it `shouldShow`, as that name has no meaning to the classic component class:
+
+```js {data-filename=app/components/flash-message.js}
+import Component from '@ember/component';
+
+export default Component.extend({
+  shouldHide: false,
+
+  dismissMessage() {
+    this.set('shouldShow', false);
+  }
+});
+```
+
+Now we wrap the template in a conditional:
+
+```handlebars {data-filename=app/components/flash-message.hbs}
+{{#if}}
+  <p>You received a message: "{{@message}}"</p>
+
+  <button type="button" {{action 'dismissMessage'}}>Dismiss</button>
+{{{/if}}}
+```
+
+As mentioned this has the drawback of still rendering the wrapping `div`, so next we'll see how we can use that to our advantage!
+
+#### Using the hidden HTML attribute
+
+There is an HTML attribute that you can use whenever you want an element to now show to the end user, the `hidden` attribute.
+To update our `FlashMessage` component to use it, we need to use the `attributeBindings` API.
+
+To avoid confusing about the state of the component, we will use the `shouldHide` name for the property that holds the state,
+and flip the values:
+
+```js {data-filename=app/components/flash-message.js}
+import Component from '@ember/component';
+
+export default Component.extend({
+  attributeBindings: ['shouldHide:hidden'],
+  shouldHide: false,
+
+  dismissMessage() {
+    this.set('shouldHide', true);
+  }
+});
+```
+
+The template remains the same in this case:
+
+```handlebars {data-filename=app/components/flash-message.hbs}
+<p>You received a message: "{{@message}}"</p>
+
+<button type="button" {{action 'dismissMessage'}}>Dismiss</button>
+```
+
+#### Using a Glimmer component
+
+If you are looking to upgrade straight to a Glimmer component, which doesn't have a wrapper `div`,
+you need to do something slightly different.
+
+First, let's update the class:
+
+```js {data-filename=app/components/flash-message.js}
 import Component from '@glimmer/component';
-import { A } from '@ember/array';
-export default class MyQuestion extends Component {
-  get students() {
-    return A(['john', 'peter']);
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class FlashMessageComponent extends Component {
+  @tracked shouldHide = false,
+
+  @action
+  dismissMessage() {
+    this.shouldHide = true;
   }
 }
 ```
 
-```handlebars {data-filename=app/templates/components/my-question.hbs}
-{{! `if` helper }}
-{{#if this.students.length}}
-  <MyComponent />
-{{/if}}
+And now let's tweak the template:
+
+```handlebars {data-filename=app/components/flash-message.hbs}
+<div hidden={{this.shouldHide}}>
+  <p>You received a message: "{{@message}}"</p>
+
+  <button type="button" {{on 'click' this.dismissMessage}}>Dismiss</button>
+</div>
 ```
 
-or in the HTML element, we can use the [`hidden`] (https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden) attribute and pass the value dynamically:
-
-```js {data-filename=app/templates/components/my-question.js}
-import Component from '@glimmer/component';
-export default class MyQuestions extends Component {
-  get hideMe() {
-    return true;
-  }
-}
-```
-
-```handlebars {data-filename=app/templates/components/my-question.hbs}
-{{! `hidden` attribute }}
-<div hidden={{this.hideMe}}></div>
-```
+As you can see, we added a wrapper `div` so we could use the `hidden` HTML attribute.
+We also switched from using `{{action}}` to using `{{on}}`.


### PR DESCRIPTION
I rewrote the guide to use a common base component for all examples, and added a Glimmer component suggestion given this was deprecated in 3.15 which is Octane by default.
I tried coming up with a self-contained use case, hence the component hiding itself. I am not sure how `isVisible` is actually used in practice, so please comment if you are looking for guidance on updating your usage.

In the `attributeBindings` example I flipped the logic so I don't have to explain the microsyntax of `attributeBindings: ['shouldShow::hide']`, and I used `attributeBindings` so it is applicable to any tagful component.
I did not mention tagless classic components because that's already a more advanced usage and didn't want to muddle the explanation.

Lastly, our general recommendation is that we use classic syntax for classic components, hence my use of `{{action}}` in the example, as that is likely what the reader is also using.