### PR TITLE
Update IDs on deprecations to match actual deprecations for Ember Data

### DIFF
--- a/app/templates/components/toc-section.hbs
+++ b/app/templates/components/toc-section.hbs
@@ -14,7 +14,7 @@
     <ul aria-labelledby={{this.id}} class="level-3 list-unstyled">
       {{#each @result.contents as |content|}}
         <li>
-          <a class="bg-none" href="#{{id-for-deprecation content.id}}" onclick={{action "navigateToLink"}}>
+          <a class="bg-none" href="#{{id-for-deprecation content.id content.anchor}}" onclick={{action "navigateToLink"}}>
             {{content.title}}
           </a>
         </li>

--- a/content/ember-data/v3/evented-api.md
+++ b/content/ember-data/v3/evented-api.md
@@ -1,5 +1,5 @@
 ---
-id: evented-api-usage
+id: ember-data:evented-api-usage
 title: Evented Api Usage
 until: '4.0.0'
 since: '3.12.0'

--- a/content/ember-data/v3/evented-api.md
+++ b/content/ember-data/v3/evented-api.md
@@ -3,6 +3,7 @@ id: ember-data:evented-api-usage
 title: Evented Api Usage
 until: '4.0.0'
 since: '3.12.0'
+anchor: toc_evented-api-usage
 ---
 As described in ['RFC 0329'](https://github.com/emberjs/rfcs/pull/329) -
 > Ember.Evented functionality on DS.Model, DS.ManyArray, DS.Errors, DS.RecordArray, and DS.PromiseManyArray will be deprecated and eventually removed in a future release. This includes the following methods from the Ember.Evented class: has, off, on, one, and trigger.

--- a/content/ember-data/v3/record-lifecycle-event-methods.md
+++ b/content/ember-data/v3/record-lifecycle-event-methods.md
@@ -3,6 +3,7 @@ id: ember-data:record-lifecycle-event-methods
 title: Record Lifecycle Event Methods
 until: '4.0.0'
 since: '3.12.0'
+anchor: toc_record-lifecycle-event-methods
 ---
 #### Deprecating Record Lifecycle Event Methods
 As described in ['RFC 0329'](https://github.com/emberjs/rfcs/pull/329) -

--- a/content/ember-data/v3/record-lifecycle-event-methods.md
+++ b/content/ember-data/v3/record-lifecycle-event-methods.md
@@ -1,5 +1,5 @@
 ---
-id: record-lifecycle-event-methods
+id: ember-data:record-lifecycle-event-methods
 title: Record Lifecycle Event Methods
 until: '4.0.0'
 since: '3.12.0'

--- a/content/ember-data/v3/toJSON.md
+++ b/content/ember-data/v3/toJSON.md
@@ -2,6 +2,7 @@
 id: ember-data:model.toJSON
 title: Record toJSON usage
 until: '4.0.0'
+anchor: toc_record-toJSON
 since: '3.12.0'
 ---
 #### Deprecates the built in `record.toJSON`

--- a/content/ember-data/v3/toJSON.md
+++ b/content/ember-data/v3/toJSON.md
@@ -1,5 +1,5 @@
 ---
-id: record.toJSON
+id: ember-data:model.toJSON
 title: Record toJSON usage
 until: '4.0.0'
 since: '3.12.0'


### PR DESCRIPTION
* added `ember-data:` prefix so that copy/paste works in deprecation-workflow
* updated toJSON file, since in code the id is `model.toJSON`, not `record.toJSON`

Links to actual deprecations in code: 
`model.toJSON`: https://github.com/emberjs/data/blob/85dbc55e7989157307ab897ac0b126bd777a724b/packages/model/addon/-private/model.js#L1344
`evented-api-usage': https://github.com/emberjs/data/blob/85dbc55e7989157307ab897ac0b126bd777a724b/packages/store/addon/-private/system/deprecated-evented.js#L48
'record-lifecycle-event-methods': https://github.com/emberjs/data/blob/85dbc55e7989157307ab897ac0b126bd777a724b/packages/model/addon/-private/model.js#L1474