### PR TITLE
Fix typo that creates confusing error when followed

### DIFF
--- a/content/ember-data/v3/default-adapter.md
+++ b/content/ember-data/v3/default-adapter.md
@@ -15,7 +15,7 @@ If you were not setting this value previously, the following should be sufficien
 create the file app/adapters/application.js with the following:
 
 ```js
-    export { default } from '@ember-data/adapters/json-api';
+    export { default } from '@ember-data/adapter/json-api';
 ```
 
 


### PR DESCRIPTION
A new ember app has a deprecation warning reported by default. Following the warning takes you to this deprecation and there is a typo in the sample code. If this is followed it then introduces a new error that says the adapter does not exist. 