### PR TITLE
Refactor toc-anchor to be accessible

### DIFF
--- a/app/components/deprecation-article.js
+++ b/app/components/deprecation-article.js
@@ -69,14 +69,6 @@ export default class DeprecationArticle extends Component {
       });
     }
 
-    element.querySelectorAll(".anchorable-toc").forEach(function (currentToc) {
-      let link = document.createElement('a');
-      link.classList.add('bg-none', 'toc-anchor');
-      link.setAttribute('href', `#${currentToc.getAttribute('id')}`);
-      link.appendChild(currentToc);
-      element.prepend(link);
-    });
-
     this.prism.highlight();
   }
 }

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -95,6 +95,38 @@ table {
   width: 1px;
 }
 
+// h3 headings used in deprecation-article component
+.anchorable-toc {
+  position: relative;
+
+  &:hover .toc-anchor,
+  &:target .toc-anchor {
+    opacity: 1;
+  }
+}
+
+// anchor links used on h3 headings
+.toc-anchor {
+  align-items: center;
+  display: flex;
+  height: 1.5em;
+  opacity: 0;
+  padding-right: 0.25em;
+  position: absolute;
+  right: 100%;
+  top: 0;
+
+  main &,
+  main &:link,
+  main &:visited {
+    background: none;
+  }
+
+  &:hover {
+    opacity: 0.75;
+  }
+}
+
 @media (max-width: 1007px) {
   body.no-scroll {
     overflow: hidden;

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -95,31 +95,17 @@ table {
   width: 1px;
 }
 
-// h3 headings used in deprecation-article component
-.anchorable-toc {
-  position: relative;
-
-  &:hover .toc-anchor,
-  &:target .toc-anchor {
-    opacity: 1;
-  }
-}
-
 // anchor links used on h3 headings
 .toc-anchor {
-  align-items: center;
-  display: flex;
-  height: 1.5em;
-  opacity: 0;
-  padding-right: 0.25em;
-  position: absolute;
-  right: 100%;
-  top: 0;
+  display: inline;
+  margin-right: var(--spacing-1);
 
+  &,
   main &,
   main &:link,
   main &:visited {
     background: none;
+    color: var(--color-gray-500);
   }
 
   &:hover {

--- a/app/templates/components/deprecation-article.hbs
+++ b/app/templates/components/deprecation-article.hbs
@@ -1,9 +1,7 @@
 <div class="padding-vertical-small bg-light-muted rounded-sm" {{did-insert this.setupCodeSnippets}}>
-  <h3 class="anchorable-toc" id="{{id-for-deprecation @model.id @model.anchor}}">
-    <a class="toc-anchor bg-none" aria-hidden="true" href="#{{id-for-deprecation @model.id @model.anchor}}">
-      <svg viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true">
-        <path d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z" />
-      </svg>
+  <h3 id="{{id-for-deprecation @model.id @model.anchor}}">
+    <a href="#{{id-for-deprecation @model.id @model.anchor}}" title={{@model.title}} class="toc-anchor">
+      §
     </a>
     {{@model.title}}
   </h3>

--- a/app/templates/components/deprecation-article.hbs
+++ b/app/templates/components/deprecation-article.hbs
@@ -1,5 +1,12 @@
 <div class="padding-vertical-small bg-light-muted rounded-sm" {{did-insert this.setupCodeSnippets}}>
-  <h3 class="anchorable-toc" id="{{id-for-deprecation @model.id @model.anchor}}">{{@model.title}}</h3>
+  <h3 class="anchorable-toc" id="{{id-for-deprecation @model.id @model.anchor}}">
+    <a class="toc-anchor bg-none" aria-hidden="true" href="#{{id-for-deprecation @model.id @model.anchor}}">
+      <svg viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true">
+        <path d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z" />
+      </svg>
+    </a>
+    {{@model.title}}
+  </h3>
   <p class="em">
     {{#if @renderIdOrUntil}}
       <div><span class="bold">until: </span>{{@model.until}}</div>


### PR DESCRIPTION
This PR attempts to close #592

- Refactored js code from `deprecation-article.js` to `deprecation-article.hbs`
- Use an icon to display the anchor while hovering the heading the same way GitHub markdown handles it

## Screenshots

Default state

![image](https://user-images.githubusercontent.com/127994/97794250-e4743a00-1bcd-11eb-8a7d-7215db76a29a.png)

Anchor Icon shows up while hovering the heading

![image](https://user-images.githubusercontent.com/127994/97794242-d3c3c400-1bcd-11eb-8c8c-22d36dc422f7.png)
