### PR TITLE
add guide for tryInvoke deprecation

### DIFF
--- a/content/ember/v3/try-invoke.md
+++ b/content/ember/v3/try-invoke.md
@@ -1,0 +1,28 @@
+---
+id: ember-utils.try-invoke
+title: tryInvoke from @ember/utils
+until: '4.0.0'
+since: 'Upcoming Features'
+---
+
+`tryInvoke` from the `@ember/utils` package is now deprecated.
+
+In most cases, function arguments should not be optional, but in the rare occasion that an argument is optional by design, we can replace `tryInvoke` with JavaScript's [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining).
+
+Before:
+
+```javascript
+import { tryInvoke } from '@ember/utils';
+
+foo() {
+ tryInvoke(this.args, 'bar', ['baz']);
+}
+```
+
+After:
+
+```javascript
+foo() {
+ this.args.bar?.('baz');
+}
+```


### PR DESCRIPTION
Adds guide for [tryInvoke deprecation](https://emberjs.github.io/rfcs/0674-deprecate-transition-methods-of-controller-and-route.html).

I adjusted the text from the RFC to something that felt smoother, please review!