### PR TITLE
Upgraded ember-cli-dependency-lint to v2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11061,8 +11061,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "binaryextensions": {
       "version": "2.1.2",
@@ -18094,9 +18093,9 @@
       }
     },
     "ember-cli-dependency-lint": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/ember-cli-dependency-lint/-/ember-cli-dependency-lint-1.1.3.tgz",
-      "integrity": "sha512-v836nMZuYhnvZ7MvIwGkwJkFhx7gc7RrlNcD90IHdBpR7kWBXIljLgSNIae84qKn1V1UqHImBTMnJvJCe2qvQw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-dependency-lint/-/ember-cli-dependency-lint-2.0.0.tgz",
+      "integrity": "sha512-HMjGqotv4YIy6mcfD0uTK2yrmGYX6/awbfSN0A4DO/IQt2tEgQofCU303n7In/HGOxwyYSX0ZB8O5BHdFwr94A==",
       "dev": true,
       "requires": {
         "archy": "^1.0.0",
@@ -25094,7 +25093,6 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
           "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-extglob": "^2.1.1"
           }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "ember-cli-babel": "^7.23.0",
     "ember-cli-cjs-transform": "^2.0.0",
     "ember-cli-dependency-checker": "^3.2.0",
-    "ember-cli-dependency-lint": "^1.1.3",
+    "ember-cli-dependency-lint": "^2.0.0",
     "ember-cli-deploy": "^1.0.2",
     "ember-cli-deploy-build": "^2.0.0",
     "ember-cli-deploy-prember-algolia": "^1.0.1",


### PR DESCRIPTION
When I would run `npm install`, the local lockfile would not match that from the default branch.

I recreated the lockfile and upgraded `ember-cli-dependency-lint` to `v2.0.0`.