### PR TITLE
Improve readability of deprecation lists

### DIFF
--- a/app/templates/components/toc-section.hbs
+++ b/app/templates/components/toc-section.hbs
@@ -12,8 +12,8 @@
 {{#if this.open}}
   <div>
     <ul aria-labelledby={{this.id}} class="level-3 list-unstyled">
-      {{#each @result.contents as |content|}}
-        <li>
+      {{#each @result.contents as |content index|}}
+        <li class={{if index "mt-2"}}>
           <a class="bg-none" href="#{{id-for-deprecation content.id content.anchor}}" onclick={{action "navigateToLink"}}>
             {{content.title}}
           </a>


### PR DESCRIPTION
Addresses #716.

Adds spacing between the list items of deprecation lists.
Went with this approach because it was my personal favourite (clear and clean).
Let me know if you guys prefer a different approach.

Result:
<img width="255" alt="Screenshot 2020-11-19 at 17 14 45" src="https://user-images.githubusercontent.com/7403183/99692710-e45bb180-2a8a-11eb-9a74-2eed0cfcb780.png">