### PR TITLE
fix(ember-string.prototype-extensions): override anchor to match deprecation

### DIFF
--- a/content/ember/v3/ember-string-prototype-extensions.md
+++ b/content/ember/v3/ember-string-prototype-extensions.md
@@ -3,6 +3,7 @@ id: ember-string.prototype-extensions
 title: Deprecate String prototype extensions
 until: '4.0.0'
 since: '3.24'
+anchor: toc_ember-string-prototype_extensions
 ---
 
 Calling one of the [Ember `String` methods](https://api.emberjs.com/ember/3.22/classes/String) (camelize, capitalize, classify, dasherize, decamelize, underscore) directly on a string is deprecated.


### PR DESCRIPTION
This overrides the auto-generated anchor for `ember-string.prototype-extensions` to match what is [reported by the deprecation in ember-source](
https://github.com/emberjs/ember.js/blob/26f4affe636bfacd517418252b0867ed6962ce6c/packages/%40ember/string/index.ts#L311) (use an underscore between "prototype" and "extensions" rather than the auto-generated `-` that is currently used: https://deprecations.emberjs.com/v3.x/#toc_ember-string-prototype-extensions