### PR TITLE
Deprecate importing htmlSafe and isHTMLSafe from @ember/string

### DIFF
--- a/content/ember/v3/ember-string-htmlsafe-ishtmlsafe.md
+++ b/content/ember/v3/ember-string-htmlsafe-ishtmlsafe.md
@@ -1,0 +1,34 @@
+---
+id: ember-string.htmlsafe-ishtmlsafe
+title: Deprecate importing htmlSafe and isHTMLSafe from @ember/string
+until: '4.0.0'
+since: '3.25'
+---
+
+Importing `htmlSafe` and `isHTMLSafe` from `@ember/string` is deprecated.
+
+You should instead import these functions from `@ember/template`.
+
+Before:
+
+```js
+import { htmlSafe, isHTMLSafe } from '@ember/string';
+
+let htmlString = "<h1>Hamsters are the best!</h1>";
+isHTMLSafe(htmlString); //=> false
+
+let htmlSafeString = htmlSafe(htmlString);
+isHTMLSafe(htmlSafeString); //=> true
+```
+
+After:
+
+```js
+import { htmlSafe, isHTMLSafe } from '@ember/template';
+
+let htmlString = "<h1>Hamsters are the best!</h1>";
+isHTMLSafe(htmlString); //=> false
+
+let htmlSafeString = htmlSafe(htmlString);
+isHTMLSafe(htmlSafeString); //=> true
+```


### PR DESCRIPTION
This adds deprecation documentation to go with https://github.com/emberjs/ember.js/pull/19339