### PR TITLE
Adds old manager capabilities deprecations

### DIFF
--- a/content/ember/v3/manager-capabilities-components.md
+++ b/content/ember/v3/manager-capabilities-components.md
@@ -1,0 +1,17 @@
+---
+id: manager-capabilities.components-3-4
+title: "3.4 Component Manager Capabilities"
+until: '4.0.0'
+since: 'Upcoming Features'
+---
+
+Any component managers using the `3.4` capabilities should update to the most
+recent component capabilities that are available, currently `3.13`. In `3.13`,
+the only major change is that update hooks are no longer called by default. If
+you need update hooks, use the `updateHook` capability:
+
+```js
+capabilities({
+  updateHook: true,
+});
+```

--- a/content/ember/v3/manager-capabilities-modifiers.md
+++ b/content/ember/v3/manager-capabilities-modifiers.md
@@ -1,0 +1,80 @@
+---
+id: manager-capabilities.modifiers-3-13
+title: "3.13 Modifier Manager Capabilities"
+until: '4.0.0'
+since: 'Upcoming Features'
+---
+
+Any modifier managers using the `3.13` capabilities should update to the most
+recent modifier capabilities, currently `3.22`. In `3.22`, the major changes
+are:
+
+1. The modifier definition, associated via `setModifierManager` is passed
+   directly to `create`, rather than a factory wrapper class. Previously, you
+   would access the class via the `class` property on the factory wrapper:
+
+   ```js
+   // before
+   class CustomModifierManager {
+     capabilities = capabilities('3.13');
+
+     createModifier(Definition, args) {
+       return new Definition.class(args);
+     }
+   }
+   ```
+
+   This can be updated to use the definition directly:
+
+   ```js
+   // after
+   class CustomModifierManager {
+     capabilities = capabilities('3.22');
+
+     createModifier(Definition, args) {
+       return new Definition(args);
+     }
+   }
+   ```
+
+2. Args are both lazy and autotracked by default. This means that in order to
+   track an argument value, you must actually use it in your modifier. If you do
+   not, the modifier will not update when the value changes.
+
+   If you still need the modifier to update whenever a value changes, even if it
+   was not used, you can manually access every value in the modifiers
+   `installModifier` and `updateModifier` lifecycle hooks:
+
+   ```js
+   function consumeArgs(args) {
+     for (let key in args.named) {
+       // consume value
+       args.named[key];
+     }
+
+     for (let i = 0; i < args.positional.length; i++) {
+       // consume value
+       args.positional[i];
+     }
+   }
+
+   class CustomModifierManager {
+     capabilities = capabilities('3.22');
+
+     installModifier(bucket, element, args) {
+       consumeArgs(args);
+
+       // ...
+     }
+
+     updateModifier(bucket, args) {
+       consumeArgs(args);
+
+       // ...
+     }
+   }
+   ```
+
+   In general this should be avoided, however, and users who are writing
+   modifiers should instead use the value if they want it to be tracked by the
+   modifier.


### PR DESCRIPTION
Adds the deprecations specified in [RFC 686](https://github.com/emberjs/rfcs/blob/master/text/0686-deprecate-old-manager-capabilities-versions.md)