### PR TITLE
Update Route render method deprecation version

### DIFF
--- a/content/ember/v3/route-disconnect-outlet.md
+++ b/content/ember/v3/route-disconnect-outlet.md
@@ -2,7 +2,7 @@
 id: route-disconnect-outlet
 title: Deprecate `Route#disconnectOutlet`
 until: '4.0.0'
-since: '3.26'
+since: 'Upcoming Features'
 ---
 
 `Route#disconnectOutlet` is intended to be used in conjunction with `Route#render`. As `render` is deprecated and `disconnectOutlet` is primarily used to teardown named outlets setup by `render`, it is also deprecated. See [RFC #491](https://emberjs.github.io/rfcs/0491-deprecate-disconnect-outlet.html).

--- a/content/ember/v3/route-render-template.md
+++ b/content/ember/v3/route-render-template.md
@@ -2,7 +2,7 @@
 id: route-render-template
 title: Deprecate `Route#renderTemplate`
 until: '4.0.0'
-since: '3.26'
+since: 'Upcoming Features'
 ---
 
 The `Route#render` and `Route#renderTemplate` APIs have been deprecated. These APIs are largely holdovers from a time where components where not as prominent in your typical Ember application and are no longer relevant. See [RFC #418](https://emberjs.github.io/rfcs/0418-deprecate-route-render-methods.html).


### PR DESCRIPTION
When I initially created these docs I assumed the `Route#render`, `Route#renderTemplate` and `Route#disconnectOutlet` deprecations would ship with 3.26. They will actually ship with 3.27.