### PR TITLE
Fix metadata for deprecate-intimate-destroy-apis

### DIFF
--- a/content/ember/v3/deprecate-intimate-meta-destroy-apis.md
+++ b/content/ember/v3/deprecate-intimate-meta-destroy-apis.md
@@ -1,8 +1,8 @@
 ---
 id: meta-destruction-apis
 title: Meta Destruction APIs
-until: 3.25.0
-since: 3.21.0
+until: "3.25.0"
+since: "3.21"
 ---
 
 We are deprecated usage of `Ember.meta`  destruction apis.


### PR DESCRIPTION
The metadata for this deprecations presented two incongruences:

1. They were not explicitly marked as strings
1. "since" specified the patch version, unlike other deprecations