### PR TITLE
Add v4 deprecation section and deprecation for Ember.assign

### DIFF
--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -47,5 +47,11 @@
         <li class="list-unstyled" data-test-ember-data-3-link><LinkTo @route='show' @models={{array 'ember-data' 'v3.x'}}>Ember Data</LinkTo></li>
       </ul>
     </li>
+    <li class="item list-unstyled">
+      <EmberVersionGraphic @mascot='zoey' @text='4.x' />
+      <ul class="links">
+        <li class="list-unstyled" data-test-ember-3-link><LinkTo @route='ember' @model='v4.x'>Ember</LinkTo></li>
+      </ul>
+    </li>
   </ul>
 </div>

--- a/content/ember/v4/deprecate-assign.md
+++ b/content/ember/v4/deprecate-assign.md
@@ -1,0 +1,24 @@
+---
+id: ember-polyfills.deprecate-assign
+title: Ember.assign
+until: '5.0.0'
+since: '4.0.0'
+---
+
+Use of `Ember.assign` is deprecated. You should replace any calls to `Ember.assign` with `Object.assign` or use the object spread operator.
+
+Before:
+``` javascript
+import { assign } from '@ember/polyfills';
+
+var a = { first: 'Yehuda' };
+var b = { last: 'Katz' };
+assign(a, b); // a == { first: 'Yehuda', last: 'Katz' }, b == { last: 'Katz' }
+```
+
+After:
+``` javascript
+var a = { first: 'Yehuda' };
+var b = { last: 'Katz' };
+Object.assign(a, b); // a == { first: 'Yehuda', last: 'Katz' }, b == { last: 'Katz' }
+```

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -14,9 +14,11 @@ module.exports = function (defaults) {
     prember: {
       urls: [
         '/',
+        '/v4.x',
         '/v3.x',
         '/v2.x',
         '/v1.x',
+        '/ember/v4.x',
         '/ember/v3.x',
         '/ember/v2.x',
         '/ember/v1.x',

--- a/lib/content-docs-generator/index.js
+++ b/lib/content-docs-generator/index.js
@@ -9,6 +9,7 @@ const contentFolders = [
   'ember/v1',
   'ember/v2',
   'ember/v3',
+  'ember/v4',
   'ember-data/v2',
   'ember-data/v3',
   'ember-cli/v2',


### PR DESCRIPTION
Completes #898 

I used the same hamster from 3.0 for a placeholder, can use a different asset if someone points me to it. Also needed to update `config/dependency-lint.js` to get lint passing.