### PR TITLE
add `htmlSafe` to list of deprecated string methods

### DIFF
--- a/content/ember/v3/ember-string-prototype-extensions.md
+++ b/content/ember/v3/ember-string-prototype-extensions.md
@@ -6,7 +6,7 @@ since: '3.24'
 anchor: toc_ember-string-prototype_extensions
 ---
 
-Calling one of the [Ember `String` methods](https://api.emberjs.com/ember/3.22/classes/String) (camelize, capitalize, classify, dasherize, decamelize, underscore) directly on a string is deprecated.
+Calling one of the [Ember `String` methods](https://api.emberjs.com/ember/3.22/classes/String) (camelize, capitalize, classify, dasherize, decamelize, htmlSafe, underscore) directly on a string is deprecated.
 
 While Ember addons (`ember addon …`) have prototype extensions disabled by default, they are enabled for applications (`ember new …`) making you able to call `"Tomster".dasherize()`, for example.
 Instead of calling the method on the string, you should instead import the function from `@ember/string`.
@@ -20,6 +20,7 @@ mascot.camelize();   //=> "empressZoey"
 mascot.capitalize(); //=> "Empress Zoey"
 mascot.classify();   //=> "EmpressZoey"
 mascot.decamelize(); //=> "empress zoey"
+mascot.htmlSafe();   //=> { string: "Empress Zoey" }
 mascot.underscore(); //=> "empress_zoey"
 mascot.w();          //=> [ "Empress", "Zoey" ]
 ```
@@ -35,6 +36,7 @@ import  {
   underscore, 
   w, 
 } from "@ember/string";
+import { htmlSafe } from '@ember/template';
 
 let mascot = "Empress Zoey";
 
@@ -42,6 +44,7 @@ camelize(mascot);   //=> "empressZoey"
 capitalize(mascot); //=> "Empress Zoey"
 classify(mascot);   //=> "EmpressZoey"
 decamelize(mascot); //=> "empress zoey"
+htmlSafe(mascot);   //=> { string: "Empress Zoey" }
 underscore(mascot); //=> "empress_zoey"
 w(mascot);          //=> [ "Empress", "Zoey" ]
 ```


### PR DESCRIPTION
See [this comment](https://github.com/emberjs/ember.js/pull/19654#issuecomment-890386906) and [this PR](https://github.com/emberjs/ember.js/pull/19690).

cc: @mixonic 