### PR TITLE
Update deprecation until for ember-env.old-extend-prototypes

### DIFF
--- a/content/ember/v3/ember-env-old-extend-prototypes.md
+++ b/content/ember/v3/ember-env-old-extend-prototypes.md
@@ -1,7 +1,7 @@
 ---
 id: ember-env.old-extend-prototypes
 title: Old extend protptypes
-until: '5.0.0'
+until: '4.0.0'
 since: '3.3.0'
 ---
 


### PR DESCRIPTION
This was incorrect - it is removed in master so it's "until" v4.