### PR TITLE
Remove duplicate headers

### DIFF
--- a/content/ember/v3/deprecated-run-loop-and-computed-dot-access.md
+++ b/content/ember/v3/deprecated-run-loop-and-computed-dot-access.md
@@ -2,7 +2,7 @@
 id: deprecated-run-loop-and-computed-dot-access
 title: Run loop and computed dot access
 until: '4.0.0'
-since: '3.27.0'
+since: '3.27'
 ---
 
 Using `.` to access computed or run loop functions has been deprecated, such

--- a/content/ember/v3/ember-env-old-extend-prototypes.md
+++ b/content/ember/v3/ember-env-old-extend-prototypes.md
@@ -2,7 +2,7 @@
 id: ember-env.old-extend-prototypes
 title: Old extend prototypes
 until: '4.0.0'
-since: '3.3.0'
+since: '3.3'
 ---
 
 Accessing `Ember.EXTEND_PROTOTYPES` is deprecated.

--- a/content/ember/v3/ember-source-deprecation-without-for.md
+++ b/content/ember/v3/ember-source-deprecation-without-for.md
@@ -2,7 +2,7 @@
 id: ember-source-deprecation-without-for
 title: Without for
 until: '4.0.0'
-since: '3.24.0'
+since: '3.24'
 ---
 
 (This deprecation guide needs details.

--- a/content/ember/v3/ember-source-deprecation-without-since.md
+++ b/content/ember/v3/ember-source-deprecation-without-since.md
@@ -2,7 +2,7 @@
 id: ember-source-deprecation-without-since
 title: Without since
 until: '4.0.0'
-since: '3.24.0'
+since: '3.24'
 ---
 
 (This deprecation guide needs more details.

--- a/content/ember/v3/old-deprecate-method-paths.md
+++ b/content/ember/v3/old-deprecate-method-paths.md
@@ -2,7 +2,7 @@
 id: old-deprecate-method-paths
 title: Old deprecate method imports
 until: '4.0.0'
-since: '3.0.0'
+since: '3.0'
 ---
 
 Importing `deprecate` from `@ember/application/deprecations'` 

--- a/content/ember/v3/template-compiler-registerPlugin.md
+++ b/content/ember/v3/template-compiler-registerPlugin.md
@@ -2,7 +2,7 @@
 id: template-compiler.registerPlugin
 title: Class-based template compilation plugins
 until: '4.0.0'
-since: '3.27.0'
+since: '3.27'
 ---
 
 Using class based template compilation plugins is deprecated.


### PR DESCRIPTION
If a version  had both a x.x.0 and the same version
without the .0, we showed separate headers.
This removes extra .0s.

Here's what the bug looked like
<img width="305" alt="Screen Shot 2021-11-04 at 7 56 30 AM" src="https://user-images.githubusercontent.com/16627268/140309810-cfafe48f-2114-4181-ba69-4a41d45b1a05.png">
:

It would be nice to group these automatically but that's more work than dropping the `.0`