### PR TITLE
Update `until` version of `transition-methods` deprecation

### DIFF
--- a/content/ember/v3/route-controller-transition-methods.md
+++ b/content/ember/v3/route-controller-transition-methods.md
@@ -1,7 +1,7 @@
 ---
 id: routing.transition-methods
 title: Transition methods of routes and controllers
-until: '4.0.0'
+until: '5.0.0'
 since: '3.26'
 ---
 


### PR DESCRIPTION
This was bumped to v5 a while ago: https://github.com/emberjs/ember.js/pull/19571.