### PR TITLE
Remove disabled-when deprecation from v4

### DIFF
--- a/content/ember/v3/ember-link-to-disabled-when.md
+++ b/content/ember/v3/ember-link-to-disabled-when.md
@@ -1,8 +1,8 @@
 ---
 id: ember.link-to.disabled-when
 title: LinkTo @disabled-when argument
-until: '5.0.0'
-since: '4.0.0'
+until: '4.0.0'
+since: '3.27.0'
 ---
 
 Passing `@disabled-when` argument to `<LinkTo>` component has been deprecated. You can use `@disabled` instead.

--- a/content/ember/v4/link-to-disabled-when.md
+++ b/content/ember/v4/link-to-disabled-when.md
@@ -1,8 +1,0 @@
----
-id: ember.link-to.disabled-when
-title: Passing disabledWhen to LinkTo
-until: '5.0.0'
-since: '4.0.0'
----
-
-Passing the `@disabledWhen` argument to <LinkTo> is deprecated. Use the `@disabled` argument instead.'


### PR DESCRIPTION
The `link-to#disabledWhen` deprecation was to last until v4.0, and has been cleaned up. However it was added to the v4 deprecations, but should be part of 3.x. ([see the adding commit here](https://github.com/emberjs/ember.js/commit/3d027841b30660dbaf136b0590f0c09a6e1317ce#diff-4ef2173974821b22319e3588d4b1fbba945c84e9997aad54e722787802fbdaa9R592)).