### PR TITLE
Improve readability of built-in components legacy arguments

### DIFF
--- a/content/ember/v3/ember-built-in-components-legacy-arguments.md
+++ b/content/ember/v3/ember-built-in-components-legacy-arguments.md
@@ -7,7 +7,7 @@ since: '3.27'
 
 As of Ember 3.27, these are the named arguments API of the built-in components:
 
-### `<LinkTo>`
+#### `<LinkTo>`
   
 * `@route`
 * `@model`
@@ -20,7 +20,7 @@ As of Ember 3.27, these are the named arguments API of the built-in components:
 * `@loadingClass`
 * `@disabledClass`
 
-### `<Input>`
+#### `<Input>`
 
 * `@type`
 * `@value`
@@ -29,7 +29,7 @@ As of Ember 3.27, these are the named arguments API of the built-in components:
 * `@enter`
 * `@escape-press`
 
-### `<Textarea>`
+#### `<Textarea>`
 
 * `@value`
 * `@insert-newline`

--- a/content/ember/v3/ember-built-in-components-legacy-arguments.md
+++ b/content/ember/v3/ember-built-in-components-legacy-arguments.md
@@ -7,29 +7,34 @@ since: '3.27'
 
 As of Ember 3.27, these are the named arguments API of the built-in components:
 
-* `<LinkTo>`
-  * `@route`
-  * `@model`
-  * `@models`
-  * `@query`
-  * `@replace`
-  * `@disabled`
-  * `@current-when`
-  * `@activeClass`
-  * `@loadingClass`
-  * `@disabledClass`
-* `<Input>`
-  * `@type`
-  * `@value`
-  * `@checked`
-  * `@insert-newline`
-  * `@enter`
-  * `@escape-press`
-* `<Textarea>`
-  * `@value`
-  * `@insert-newline`
-  * `@enter`
-  * `@escape-press`
+### `<LinkTo>`
+  
+* `@route`
+* `@model`
+* `@models`
+* `@query`
+* `@replace`
+* `@disabled`
+* `@current-when`
+* `@activeClass`
+* `@loadingClass`
+* `@disabledClass`
+
+### `<Input>`
+
+* `@type`
+* `@value`
+* `@checked`
+* `@insert-newline`
+* `@enter`
+* `@escape-press`
+
+### `<Textarea>`
+
+* `@value`
+* `@insert-newline`
+* `@enter`
+* `@escape-press`
 
 In order to reduce their API surfaces, all other arguments on these components
 have been deprecated. The arguments not enumerated above are either no longer


### PR DESCRIPTION
Before:
<img width="186" alt="Screenshot 2021-12-16 at 08 15 18" src="https://user-images.githubusercontent.com/7403183/146325243-1049bf07-43dd-48a9-aa01-eb999538dcbb.png">

After:
<img width="203" alt="Screenshot 2021-12-16 at 08 15 31" src="https://user-images.githubusercontent.com/7403183/146325274-a1145cab-ebd5-4755-b78b-725daf9aa090.png">