### PR TITLE
Clarify deprecation instructions for auto-location

### DIFF
--- a/content/ember/v4/auto-location.md
+++ b/content/ember/v4/auto-location.md
@@ -22,6 +22,20 @@ These days, virtually all browsers support the history API, so 'auto' will alway
 Set `locationType` in `config/environment.js` to `'history'`. This is it. 
 Your app should work just like it used to.
 
+~~~js
+// config/environment.js
+'use strict';
+
+module.exports = function (environment) {
+  let ENV = {
+    modulePrefix: 'my-app',
+    environment: environment,
+    rootURL: '/',
+    locationType: 'history', // add or edit this line
+    …
+};
+~~~
+
 #### Advanced Stuff
 
 1. Note that the 'hash' location type is still around, you just have to set it manually.

--- a/content/ember/v4/auto-location.md
+++ b/content/ember/v4/auto-location.md
@@ -7,29 +7,31 @@ since: '4.1.0'
 
 #### Background
 
-Several years ago only some browsers supported the (then) new History Location API.
-Others could only serialize the router location into an url hash `my/path#/ember/route`.
+Several years ago (in Ember v1 days) few browsers supported the History Location API,
+and other browsers could only serialize the router location into an URL hash `my/path#/ember/route`.
 
-To handle this dynamically, Ember built an AutoLocation that would feature-detect
-and use either 'hash' or 'history' as the underlying mechanism.
+To handle this dynamically, Ember had an AutoLocation class that would use feature-detection to 
+determine if the browser supported the History Location API, and use either 'hash' or 'history' 
+as the underlying mechanism.
 
-These days, virtually all browsers support the history API, so this is what 'auto'
-will resolve to in almost every case. Since 'auto' has served its purpose, it's being removed.
+These days, virtually all browsers support the history API, so 'auto' will always resolve to 
+'history' as the location mechanism. Since 'auto' has served its purpose, it's being removed.
 
 #### Required Changes
 
-Set `locationType` in `config/environment.js` to `'history'`. This is it,
-your app should work just like it used to.
-
-Unless you know for sure that you need to keep feature detection in place (few need that),
-or that you'd like to use the 'hash' location strategy (rarely used in browsers,
-but can be useful for mobile apps delivered via a webview).
+Set `locationType` in `config/environment.js` to `'history'`. This is it. 
+Your app should work just like it used to.
 
 #### Advanced Stuff
 
-If you implemented your own Location class and used the `detect` method,
-this one is now deprecated. If you need feature detection you can run your
-detection code in app.js, before setting the location type.
+1. Note that the 'hash' location type is still around, you just have to set it manually.
+It's sometimes used in Ember apps running inside webviews (native mobile apps), for example.
+
+2. If you implemented your own `Location` class and used the `detect` method,
+this one is now deprecated. 
+
+3. If you need feature detection you can run your detection code in app/router.js, 
+before setting the location type.
 
 ```js
 // app/router.js


### PR DESCRIPTION
@locks I've made a few adjustments here (related to this earlier PR https://github.com/ember-learn/deprecation-app/pull/882)