### PR TITLE
Add `Deprecate Bower Support` guides

### DIFF
--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -50,7 +50,8 @@
     <li class="item list-unstyled">
       <EmberVersionGraphic @mascot='zoey' @text='4.x' />
       <ul class="links">
-        <li class="list-unstyled" data-test-ember-3-link><LinkTo @route='ember' @model='v4.x'>Ember</LinkTo></li>
+        <li class="list-unstyled" data-test-ember-4-link><LinkTo @route='ember' @model='v4.x'>Ember</LinkTo></li>
+        <li class="list-unstyled" data-test-ember-cli-4-link><LinkTo @route='show' @models={{array 'ember-cli' 'v4.x'}}>Ember CLI</LinkTo></li>
       </ul>
     </li>
   </ul>

--- a/content/ember-cli/v4/blueprint.add-bower-package-to-project.md
+++ b/content/ember-cli/v4/blueprint.add-bower-package-to-project.md
@@ -1,0 +1,14 @@
+---
+id: ember-cli.blueprint.add-bower-package-to-project
+title: Blueprint::addBowerPackageToProject
+until: '5.0.0'
+since: '4.3.0'
+---
+
+`addBowerPackageToProject` has been deprecated. If the package is also available
+on the npm registry, please use `addPackageToProject` instead. If not, please
+suggest your users to install the Bower package manually by running:
+
+```bash
+bower install <package-name> --save
+```

--- a/content/ember-cli/v4/blueprint.add-bower-packages-to-project.md
+++ b/content/ember-cli/v4/blueprint.add-bower-packages-to-project.md
@@ -1,0 +1,14 @@
+---
+id: ember-cli.blueprint.add-bower-packages-to-project
+title: Blueprint::addBowerPackagesToProject
+until: '5.0.0'
+since: '4.3.0'
+---
+
+`addBowerPackagesToProject` has been deprecated. If the packages are also available
+on the npm registry, please use `addPackagesToProject` instead. If not, please
+suggest your users to install the Bower packages manually by running:
+
+```bash
+bower install <package-name> <package-name> --save
+```

--- a/content/ember-cli/v4/building-bower-packages.md
+++ b/content/ember-cli/v4/building-bower-packages.md
@@ -1,0 +1,16 @@
+---
+id: ember-cli.building-bower-packages
+title: Building Bower Packages
+until: '5.0.0'
+since: '4.3.0'
+---
+
+Building Bower packages has been deprecated.
+
+Please consider one of the following alternatives:
+
+1. Install the package via the npm registry and use `ember-auto-import` to
+import the package into your project
+2. If alternative 1 is not an option, you could copy the contents of the Bower
+package into the `/vendor` folder and use `app.import` to import the package
+into your project

--- a/content/ember-cli/v4/project.bower-dependencies.md
+++ b/content/ember-cli/v4/project.bower-dependencies.md
@@ -1,0 +1,34 @@
+---
+id: ember-cli.project.bower-dependencies
+title: Project::bowerDependencies
+until: '5.0.0'
+since: '4.3.0'
+---
+
+`bowerDependencies` has been deprecated. If you still need access to the
+project's Bower dependencies, you will have to manually resolve the project's
+`bower.json` file instead:
+
+```js
+'use strict';
+
+const fs = require('fs-extra');
+const path = require('path');
+
+module.exports = {
+  name: require('./package').name,
+
+  included() {
+    this._super.included.apply(this, arguments);
+
+    let bowerPath = path.join(this.project.root, 'bower.json');
+    let bowerJson = fs.existsSync(bowerPath) ? require(bowerPath) : {};
+    let bowerDependencies = {
+      ...bowerJson.dependencies,
+      ...bowerJson.devDependencies,
+    };
+
+    // Do something with `bowerDependencies`.
+  },
+};
+```

--- a/content/ember-cli/v4/project.bower-directory.md
+++ b/content/ember-cli/v4/project.bower-directory.md
@@ -1,0 +1,31 @@
+---
+id: ember-cli.project.bower-directory
+title: Project::bowerDirectory
+until: '5.0.0'
+since: '4.3.0'
+---
+
+`bowerDirectory` has been deprecated. If you still need access to the
+project's Bower directory, you will have to manually resolve the project's
+`.bowerrc` file and read the `directory` property instead:
+
+```js
+'use strict';
+
+const fs = require('fs-extra');
+const path = require('path');
+
+module.exports = {
+  name: require('./package').name,
+
+  included() {
+    this._super.included.apply(this, arguments);
+
+    let bowerConfigPath = path.join(this.project.root, '.bowerrc');
+    let bowerConfigJson = fs.existsSync(bowerConfigPath) ? fs.readJsonSync(bowerConfigPath) : {};
+    let bowerDirectory = bowerConfigJson.directory || 'bower_components';
+
+    // Do something with `bowerDirectory`.
+  },
+};
+```

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -25,6 +25,7 @@ module.exports = function (defaults) {
         '/ember-data/v2.x',
         '/ember-data/v3.x',
         '/ember-cli/v2.x',
+        '/ember-cli/v4.x',
       ],
     },
 

--- a/lib/content-docs-generator/index.js
+++ b/lib/content-docs-generator/index.js
@@ -13,6 +13,7 @@ const contentFolders = [
   'ember-data/v2',
   'ember-data/v3',
   'ember-cli/v2',
+  'ember-cli/v4',
 ];
 
 const jsonTrees = contentFolders.map(

--- a/tests/acceptance/visual-regression-test.js
+++ b/tests/acceptance/visual-regression-test.js
@@ -69,5 +69,25 @@ module('Acceptance | visual regression', function (hooks) {
       .hasText('Deprecations Added in Ember Data 3.x');
 
     await percySnapshot('ember-data-3.x');
+
+    // v4.x Ember
+    await click('[data-test-main-deprecations-link]');
+    await click('[data-test-ember-4-link] > a');
+
+    assert
+      .dom('[data-test-deprecations-added-in]')
+      .hasText('Deprecations Added in Ember 4.x');
+
+    await percySnapshot('ember-4.x');
+
+    // v4.x Ember CLI
+    await click('[data-test-main-deprecations-link]');
+    await click('[data-test-ember-cli-4-link] > a');
+
+    assert
+      .dom('[data-test-deprecations-added-in]')
+      .hasText('Deprecations Added in Ember CLI 4.x');
+
+    await percySnapshot('ember-cli-4.x');
   });
 });


### PR DESCRIPTION
Guides for the [Deprecate Bower Support RFC](https://github.com/emberjs/rfcs/pull/772).
Implementation: https://github.com/ember-cli/ember-cli/pull/9707.