### PR TITLE
Update 'since' version for `ember-link-to-disabled-when`

### DIFF
--- a/content/ember/v3/ember-link-to-disabled-when.md
+++ b/content/ember/v3/ember-link-to-disabled-when.md
@@ -2,7 +2,7 @@
 id: ember.link-to.disabled-when
 title: LinkTo @disabled-when argument
 until: '4.0.0'
-since: '3.27.0'
+since: '3.27'
 ---
 
 Passing `@disabled-when` argument to `<LinkTo>` component has been deprecated. You can use `@disabled` instead.


### PR DESCRIPTION
All other md files have the 'since' format of `x.xx`, and so there are entries in the TOC for 3.27 and 3.27.0.