### PR TITLE
Update htmlSafe and isHTMLSafe deprecation example

### DIFF
--- a/content/ember/v3/ember-string-htmlsafe-ishtmlsafe.md
+++ b/content/ember/v3/ember-string-htmlsafe-ishtmlsafe.md
@@ -12,13 +12,11 @@ You should instead import these functions from `@ember/template`.
 Before:
 
 ```js
-import { htmlSafe, isHTMLSafe } from '@ember/string';
-
 let htmlString = "<h1>Hamsters are the best!</h1>";
-isHTMLSafe(htmlString); //=> false
+htmlString.isHTMLSafe(); //=> false
 
-let htmlSafeString = htmlSafe(htmlString);
-isHTMLSafe(htmlSafeString); //=> true
+let htmlSafeString = htmlString.htmlSafe();
+htmlSafeString.isHTMLSafe(); //=> true
 ```
 
 After:


### PR DESCRIPTION
The `before` and `after` examples currently match.

<img width="741" alt="Screen Shot 2022-05-31 at 2 16 31 PM" src="https://user-images.githubusercontent.com/50783505/171268443-8523e3fd-d175-4cd6-8b80-22cc33ba1574.png">

Update the `before` example to use a deprecated example.


