### PR TITLE
style: change of grid template column - sidebar

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -9,7 +9,7 @@ table {
   display: grid;
   grid-template:
     "sidebar  main" auto /
-    15rem 3fr 300px;
+    25rem 3fr 300px;
 }
 
 .article-card {


### PR DESCRIPTION
This is in reference to the issue - Make the Sidebar wider(https://github.com/ember-learn/deprecation-app/issues/1058)
Please find the reference for the change: https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template
And PFB screenshots for different widths 

Screen Width: 1920px

![localhost_4200_v3 x (1)](https://user-images.githubusercontent.com/44545218/171468973-09257971-781e-4161-acbf-0d359c20e51e.png)

Screen Width: 1720px
![localhost_4200_v3 x (2)](https://user-images.githubusercontent.com/44545218/171469002-6a3a7c14-091b-4ac2-bfa0-b2c7e1e4a069.png)

Screen Width: 1366px
![localhost_4200_v3 x (3)](https://user-images.githubusercontent.com/44545218/171469028-e8c0a25a-2905-43d8-ac30-b782ae3faffb.png)

Screen Width: 1000px
![localhost_4200_v3 x (4)](https://user-images.githubusercontent.com/44545218/171469045-7f5059fb-c356-4653-8031-1d66f52193e2.png)

Screen Width: iPhone 12 Pro
![localhost_4200_v3 x(iPhone 12 Pro)](https://user-images.githubusercontent.com/44545218/171469076-e8e78dbd-4a51-4b41-bbc8-46514b72481e.png)
