### PR TITLE
Correctly apply deprecate-router-events changes

### DIFF
--- a/content/ember/v3/router-events.md
+++ b/content/ember/v3/router-events.md
@@ -41,7 +41,7 @@ export default Router.extend({
 To:
 
 ```js
-import Route from '@ember/routing/route';
+import Router from '@ember/routing/router';
 import { inject as service } from '@ember/service';
 
 export default Route.extend({

--- a/content/ember/v3/router-events.md
+++ b/content/ember/v3/router-events.md
@@ -44,7 +44,7 @@ To:
 import Router from '@ember/routing/router';
 import { inject as service } from '@ember/service';
 
-export default Route.extend({
+export default Router.extend({
   currentUser: service('current-user'),
 
   init() {


### PR DESCRIPTION
The change should be applied to the Router, not a Route.

--

Should be squashed before merging.