### PR TITLE
Mobile Deprecation version section is too long

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -581,7 +581,7 @@ p a:hover {
         width: 100%;
 
         .ember-version-graphic {
-          $height: 132px;
+          $height: 161px;
           width: $height;
           height: $height;
 
@@ -592,6 +592,14 @@ p a:hover {
 
         .links {
           border-top: 0;
+       }
+        .row{
+          display: flex;
+          flex-direction: row;
+        }
+        .column{
+          display: flex;
+          flex-direction: column;
         }
       }
     }

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -36,18 +36,24 @@
     <li class="item list-unstyled">
       <EmberVersionGraphic @mascot="ember" />
       <ul class="links">
-        <li class="list-unstyled" data-test-ember-1-link>
+        <div class="row">
+          <div class="column">
+            <li class="list-unstyled" data-test-ember-1-link>
           <LinkTo @route="ember" @model="v1.x">v1.x</LinkTo>
-        </li>
-        <li class="list-unstyled" data-test-ember-2-link>
+            </li>
+            <li class="list-unstyled" data-test-ember-2-link>
           <LinkTo @route="ember" @model="v2.x">v2.x</LinkTo>
-        </li>
-        <li class="list-unstyled" data-test-ember-3-link>
+            </li>
+            <li class="list-unstyled" data-test-ember-3-link>
           <LinkTo @route="ember" @model="v3.x">v3.x</LinkTo>
-        </li>
-        <li class="list-unstyled" data-test-ember-4-link>
+            </li>
+          </div>
+          <div class="column">
+            <li class="list-unstyled" data-test-ember-4-link>
           <LinkTo @route="ember" @model="v4.x">v4.x</LinkTo>
-        </li>
+            </li>
+          </div>
+        </div>
       </ul>
     </li>
     <li class="item list-unstyled">


### PR DESCRIPTION
#1239 

Before: 
<img width="343" alt="Screen Shot 2022-12-11 at 7 34 30 PM" src="https://user-images.githubusercontent.com/70502771/206955157-a2a358c0-0a4d-4e48-ae0e-2f069065cd34.png">

After:
<img width="349" alt="Screen Shot 2022-12-11 at 7 34 54 PM" src="https://user-images.githubusercontent.com/70502771/206955184-86260ee8-c83d-4f3d-9d5f-fd0e4ef6d0f3.png">

There is now less empty space on the right side, and the proportions just look a bit better. 


