### PR TITLE
_search-input: sass: avoid using slash as div

### DIFF
--- a/app/styles/_search-input.scss
+++ b/app/styles/_search-input.scss
@@ -1,3 +1,4 @@
+@use "sass:math";
 
 // Typography
 $base-font-family: 'Source Sans Pro', sans-serif;
@@ -16,7 +17,7 @@ $heading-line-height: 1.2;
 
 // Spacing
 $base-spacing: $base-line-height * 1em;
-$small-spacing: $base-spacing / 2;
+$small-spacing: math.div($base-spacing, 2);
 $large-spacing: $base-spacing * 2;
 $top-spacing: $base-spacing * 3.333; // 80px
 


### PR DESCRIPTION
Sass currently treats / as a division operation in some contexts and a separator in others. This makes it difficult for Sass users to tell what any given / will mean, and makes it hard to work with new CSS features that use / as a separator.

As such, Sass has deprecated its usage, and `dart-sass` (which we use in this project) flags it at build time.

To fix this issue, let's prefer `math.div` instead.

See: https://sass-lang.com/documentation/breaking-changes/slash-div for more details.

This fixes issue #1276.