### PR TITLE
package: remove unused ember/render-modifiers devDep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "devDependencies": {
         "@ember/optional-features": "^2.0.0",
-        "@ember/render-modifiers": "^1.0.2",
         "@ember/test-helpers": "^2.6.0",
         "@glimmer/component": "^1.0.4",
         "@glimmer/tracking": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
-    "@ember/render-modifiers": "^1.0.2",
     "@ember/test-helpers": "^2.6.0",
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.1.1",


### PR DESCRIPTION
Right now, we depend on the @ember/render-modifiers package, but do not actually use it.  For reference, it looks like the original dep/usage was added in `Commit: c0f373b4` and then that usage was subsequently removed in `Commit: 459a5769`.

As such, we should just be able to remove the dependency.

This should help fix one of the linter errors in #1279, as well as contribute a bit of incremental progress toward #1272.