### PR TITLE
package: fix `LinkComponent` deprecation

### DIFF
--- a/app/components/link-to.js
+++ b/app/components/link-to.js
@@ -1,4 +1,4 @@
-import LinkComponent from '@ember/routing/link-component';
+import { LinkComponent } from '@ember/legacy-built-in-components';
 
 export default class CustomLinkComponent extends LinkComponent {
   click() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
+        "@ember/legacy-built-in-components": "^0.4.1",
         "@ember/optional-features": "^2.0.0",
         "@ember/render-modifiers": "^1.0.2",
         "@ember/test-helpers": "^2.6.0",
@@ -3207,28 +3208,32 @@
       "dev": true
     },
     "node_modules/@ember/legacy-built-in-components": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@ember/legacy-built-in-components/-/legacy-built-in-components-0.4.0.tgz",
-      "integrity": "sha512-nm0tTe9d7aYpPa8sk85M4AZ3iDfuVQ4/7M4D4IdI7frkAOGpy6gAKS9nR/UR8mJDW06CLz9NYEKWIlLopEu/Og==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@ember/legacy-built-in-components/-/legacy-built-in-components-0.4.1.tgz",
+      "integrity": "sha512-tLxiU1YR+A+002rkGfwyB4FK8bO5qqU/3c7cZ1z2j3XG+1T28Yg2iZuMxPwFJ0LsE//mhRFkWlGzO3tJUtMHbA==",
       "dev": true,
       "dependencies": {
-        "@embroider/macros": "^0.47.1",
+        "@embroider/macros": "^1.0.0",
         "ember-cli-babel": "^7.26.6",
         "ember-cli-htmlbars": "^5.7.1",
         "ember-cli-typescript": "^4.1.0"
       },
       "engines": {
         "node": "12.* || 14.* || >= 16"
+      },
+      "peerDependencies": {
+        "ember-source": "*"
       }
     },
     "node_modules/@ember/legacy-built-in-components/node_modules/@embroider/macros": {
-      "version": "0.47.2",
-      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-0.47.2.tgz",
-      "integrity": "sha512-ViNWluJCeM5OPlM3rs8kdOz3RV5rpfXX5D2rDnc/q86xRS0xf4NFEjYRV7W6fBcD0b3v5jSHDTwrjq9Kee4rHg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-1.10.0.tgz",
+      "integrity": "sha512-LMbfQGk/a+f6xtvAv5fq/wf2LRxETnbgSCLUf/z6ebzmuskOUxrke+uP55chF/loWrARi9g6erFQ7RDOUoBMSg==",
       "dev": true,
       "dependencies": {
-        "@embroider/shared-internals": "0.47.2",
+        "@embroider/shared-internals": "2.0.0",
         "assert-never": "^1.2.1",
+        "babel-import-util": "^1.1.0",
         "ember-cli-babel": "^7.26.6",
         "find-up": "^5.0.0",
         "lodash": "^4.17.21",
@@ -3255,6 +3260,15 @@
       },
       "engines": {
         "node": "8.* || >= 10.*"
+      }
+    },
+    "node_modules/@ember/legacy-built-in-components/node_modules/babel-import-util": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-1.3.0.tgz",
+      "integrity": "sha512-PPzUT17eAI18zn6ek1R3sB4Krc/MbnmT1MkZQFmyhjoaEGBVwNABhfVU9+EKcDSKrrOm9OIpGhjxukx1GCiy1g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12.*"
       }
     },
     "node_modules/@ember/legacy-built-in-components/node_modules/broccoli-persistent-filter": {
@@ -4329,14 +4343,15 @@
       }
     },
     "node_modules/@embroider/shared-internals": {
-      "version": "0.47.2",
-      "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-0.47.2.tgz",
-      "integrity": "sha512-SxdZYjAE0fiM5zGDz+12euWIsQZ1tsfR1k+NKmiWMyLhA5T3pNgbR2/Djvx/cVIxOtEavGGSllYbzRKBtV4xMg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-2.0.0.tgz",
+      "integrity": "sha512-qZ2/xky9mWm5YC6noOa6AiAwgISEQ78YTZNv4SNu2PFgEK/H+Ha/3ddngzGSsnXkVnIHZyxIBzhxETonQYHY9g==",
       "dev": true,
       "dependencies": {
-        "babel-import-util": "^0.2.0",
+        "babel-import-util": "^1.1.0",
         "ember-rfc176-data": "^0.3.17",
         "fs-extra": "^9.1.0",
+        "js-string-escape": "^1.0.1",
         "lodash": "^4.17.21",
         "resolve-package-path": "^4.0.1",
         "semver": "^7.3.5",
@@ -4344,6 +4359,15 @@
       },
       "engines": {
         "node": "12.* || 14.* || >= 16"
+      }
+    },
+    "node_modules/@embroider/shared-internals/node_modules/babel-import-util": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-1.3.0.tgz",
+      "integrity": "sha512-PPzUT17eAI18zn6ek1R3sB4Krc/MbnmT1MkZQFmyhjoaEGBVwNABhfVU9+EKcDSKrrOm9OIpGhjxukx1GCiy1g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12.*"
       }
     },
     "node_modules/@embroider/shared-internals/node_modules/fs-extra": {
@@ -38656,25 +38680,26 @@
       "dev": true
     },
     "@ember/legacy-built-in-components": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@ember/legacy-built-in-components/-/legacy-built-in-components-0.4.0.tgz",
-      "integrity": "sha512-nm0tTe9d7aYpPa8sk85M4AZ3iDfuVQ4/7M4D4IdI7frkAOGpy6gAKS9nR/UR8mJDW06CLz9NYEKWIlLopEu/Og==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@ember/legacy-built-in-components/-/legacy-built-in-components-0.4.1.tgz",
+      "integrity": "sha512-tLxiU1YR+A+002rkGfwyB4FK8bO5qqU/3c7cZ1z2j3XG+1T28Yg2iZuMxPwFJ0LsE//mhRFkWlGzO3tJUtMHbA==",
       "dev": true,
       "requires": {
-        "@embroider/macros": "^0.47.1",
+        "@embroider/macros": "^1.0.0",
         "ember-cli-babel": "^7.26.6",
         "ember-cli-htmlbars": "^5.7.1",
         "ember-cli-typescript": "^4.1.0"
       },
       "dependencies": {
         "@embroider/macros": {
-          "version": "0.47.2",
-          "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-0.47.2.tgz",
-          "integrity": "sha512-ViNWluJCeM5OPlM3rs8kdOz3RV5rpfXX5D2rDnc/q86xRS0xf4NFEjYRV7W6fBcD0b3v5jSHDTwrjq9Kee4rHg==",
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-1.10.0.tgz",
+          "integrity": "sha512-LMbfQGk/a+f6xtvAv5fq/wf2LRxETnbgSCLUf/z6ebzmuskOUxrke+uP55chF/loWrARi9g6erFQ7RDOUoBMSg==",
           "dev": true,
           "requires": {
-            "@embroider/shared-internals": "0.47.2",
+            "@embroider/shared-internals": "2.0.0",
             "assert-never": "^1.2.1",
+            "babel-import-util": "^1.1.0",
             "ember-cli-babel": "^7.26.6",
             "find-up": "^5.0.0",
             "lodash": "^4.17.21",
@@ -38696,6 +38721,12 @@
             "rsvp": "^4.8.5",
             "username-sync": "^1.0.2"
           }
+        },
+        "babel-import-util": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-1.3.0.tgz",
+          "integrity": "sha512-PPzUT17eAI18zn6ek1R3sB4Krc/MbnmT1MkZQFmyhjoaEGBVwNABhfVU9+EKcDSKrrOm9OIpGhjxukx1GCiy1g==",
+          "dev": true
         },
         "broccoli-persistent-filter": {
           "version": "3.1.2",
@@ -39544,20 +39575,27 @@
       }
     },
     "@embroider/shared-internals": {
-      "version": "0.47.2",
-      "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-0.47.2.tgz",
-      "integrity": "sha512-SxdZYjAE0fiM5zGDz+12euWIsQZ1tsfR1k+NKmiWMyLhA5T3pNgbR2/Djvx/cVIxOtEavGGSllYbzRKBtV4xMg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-2.0.0.tgz",
+      "integrity": "sha512-qZ2/xky9mWm5YC6noOa6AiAwgISEQ78YTZNv4SNu2PFgEK/H+Ha/3ddngzGSsnXkVnIHZyxIBzhxETonQYHY9g==",
       "dev": true,
       "requires": {
-        "babel-import-util": "^0.2.0",
+        "babel-import-util": "^1.1.0",
         "ember-rfc176-data": "^0.3.17",
         "fs-extra": "^9.1.0",
+        "js-string-escape": "^1.0.1",
         "lodash": "^4.17.21",
         "resolve-package-path": "^4.0.1",
         "semver": "^7.3.5",
         "typescript-memoize": "^1.0.1"
       },
       "dependencies": {
+        "babel-import-util": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-1.3.0.tgz",
+          "integrity": "sha512-PPzUT17eAI18zn6ek1R3sB4Krc/MbnmT1MkZQFmyhjoaEGBVwNABhfVU9+EKcDSKrrOm9OIpGhjxukx1GCiy1g==",
+          "dev": true
+        },
         "fs-extra": {
           "version": "9.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test": "ember test"
   },
   "devDependencies": {
+    "@ember/legacy-built-in-components": "^0.4.1",
     "@ember/optional-features": "^2.0.0",
     "@ember/render-modifiers": "^1.0.2",
     "@ember/test-helpers": "^2.6.0",


### PR DESCRIPTION
Right now, we import Ember.LinkComponent to define custom click event handling.

Using Ember.LinkComponent or importing from 'LinkComponent' has been deprecated, and it is recommended to install the
`@ember/legacy-built-in-components` addon and use `import { LinkComponent } from '@ember/legacy-built-in-components';` instead [deprecation id: ember.built-in-components.import], so let's go ahead and do so.

This should help with achieving #1272.