### PR TITLE
avoid depending on implicit store injection in routes

### DIFF
--- a/app/routes/ember.js
+++ b/app/routes/ember.js
@@ -1,7 +1,10 @@
 import Route from '@ember/routing/route';
 import processResults from '../utils/process-results';
+import { inject as service } from '@ember/service';
 
 export default class EmberRoute extends Route {
+  @service store;
+
   controllerName = 'show';
   templateName = 'show';
 

--- a/app/routes/show.js
+++ b/app/routes/show.js
@@ -1,7 +1,10 @@
 import Route from '@ember/routing/route';
 import processResults from '../utils/process-results';
+import { inject as service } from '@ember/service';
 
 export default class ShowRoute extends Route {
+  @service store;
+
   async model(params) {
     let query = await this.store.query('content', {
       path: params.project,


### PR DESCRIPTION
Right now, the `ember` and `show` routes both depend on implicit injection of the store service. Ember is moving away from this paradigm, so let's migrate away from this in favor of implicit injection via the `inject` decorator.

This should help make incremental progress toward #1272.