### PR TITLE
tests: use `this` in property path in templates

### DIFF
--- a/tests/integration/helpers/id-for-deprecation-test.js
+++ b/tests/integration/helpers/id-for-deprecation-test.js
@@ -10,14 +10,14 @@ module('Integration | Helper | id-for-deprecation', function (hooks) {
     test('anchor id is prefixed with toc_', async function (assert) {
       this.set('inputValue', 'toJSON');
 
-      await render(hbs`{{id-for-deprecation inputValue}}`);
+      await render(hbs`{{id-for-deprecation this.inputValue}}`);
 
       assert.equal(this.element.textContent.trim(), 'toc_toJSON');
     });
     test('anchor id has periods, commas, and colons replaced with dashes', async function (assert) {
       this.set('inputValue', 'ember-data:object.init,constructor');
 
-      await render(hbs`{{id-for-deprecation inputValue}}`);
+      await render(hbs`{{id-for-deprecation this.inputValue}}`);
 
       assert.equal(
         this.element.textContent.trim(),
@@ -27,7 +27,7 @@ module('Integration | Helper | id-for-deprecation', function (hooks) {
     test('anchor id has whitespace stripped out', async function (assert) {
       this.set('inputValue', 'ember_object.some property');
 
-      await render(hbs`{{id-for-deprecation inputValue}}`);
+      await render(hbs`{{id-for-deprecation this.inputValue}}`);
 
       assert.equal(
         this.element.textContent.trim(),
@@ -41,7 +41,9 @@ module('Integration | Helper | id-for-deprecation', function (hooks) {
     this.set('deprecationId', 'my-deprecation');
     this.set('optionalAnchorId', anchor);
 
-    await render(hbs`{{id-for-deprecation deprecationId optionalAnchorId}}`);
+    await render(
+      hbs`{{id-for-deprecation this.deprecationId this.optionalAnchorId}}`
+    );
 
     assert.equal(this.element.textContent.trim(), anchor);
   });


### PR DESCRIPTION
When running the `id-for-deprecation-test` suite, there are several instances of the [this-property-fallback] deprecation logged to the console.

Let's make sure that we always use `this.` in the property path of our inline templates when appropriate.

This should help with #1272.