### PR TITLE
chore: replace all filename comments in code examples by proper `data-filename`

### DIFF
--- a/content/ember-data/v3/ember-data-najax-fallback.md
+++ b/content/ember-data/v3/ember-data-najax-fallback.md
@@ -40,8 +40,7 @@ export default ApplicationAdapter extends JSONAPIAdapter {
 
 b. You can also opt-in and and configure your ember-data compatibility version to `3.22` or higher. See documentation [here](https://api.emberjs.com/ember-data/release/modules/@ember-data%2Fdeprecations).
 
-```js
-// ember-cli-build.js
+```js {data-filename=ember-cli-build.js}
 let app = new EmberApp(defaults, {
     emberData: {
       compatWith: '3.22',

--- a/content/ember/v3/ember-built-in-components-import.md
+++ b/content/ember/v3/ember-built-in-components-import.md
@@ -26,9 +26,7 @@ remain "frozen" in there:
 
 Before:
 
-```js
-// app/components/my-checkbox.js
-
+```js {data-filename=app/components/my-checkbox.js}
 import Checkbox from '@ember/component/checkbox';
 //                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Using Ember.Checkbox or importing from '@ember/component/checkbox' has been
@@ -42,9 +40,7 @@ export class MyCheckbox extends Checkbox {
 
 After:
 
-```js
-// app/components/my-checkbox.js
-
+```js {data-filename=app/components/my-checkbox.js}
 import { Checkbox } from '@ember/legacy-built-in-components';
 
 export class MyCheckbox extends Checkbox {

--- a/content/ember/v3/ember-built-in-components-reopen.md
+++ b/content/ember/v3/ember-built-in-components-reopen.md
@@ -78,9 +78,7 @@ Checkbox.reopen({
 
 After:
 
-```js
-// app/components/my-checkbox.js
-
+```js {data-filename=app/components/my-checkbox.js}
 import { Checkbox } from '@ember/legacy-built-in-components';
 
 export default class MyCheckbox extends Checkbox {
@@ -159,9 +157,7 @@ Component.reopen({
 
 After:
 
-```js
-// app/components/base.js
-
+```js {data-filename=app/components/base.js}
 import Component from '@ember/component';
 
 // Subclass from this in your app, instead of subclassing from Ember.Component

--- a/content/ember/v3/ember-string-prototype-extensions.md
+++ b/content/ember/v3/ember-string-prototype-extensions.md
@@ -55,8 +55,7 @@ Keep in mind that different libraries will behave in slightly different ways, so
 
 You can also [disable String prototype extensions](https://guides.emberjs.com/release/configuring-ember/disabling-prototype-extensions/) by editing your environment file:
 
-```js
-// config/environment.js
+```js {data-filename=config/environment.js}
 ENV = {
   EmberENV: {
     EXTEND_PROTOTYPES: {

--- a/content/ember/v3/implicit-injections.md
+++ b/content/ember/v3/implicit-injections.md
@@ -72,8 +72,7 @@ injection to use services instead.
 
 Before:
 
-```js
-// app/initializers/logger.js
+```js {data-filename=app/initializers/logger.js}
 import EmberObject from '@ember/object';
 
 export function initialize(application) {
@@ -92,8 +91,7 @@ export default {
   initialize: initialize
 };
 ```
-```js
-// app/routes/application.js
+```js {data-filename=app/routes/application.js}
 export default class ApplicationRoute extends Route {
   model() {
     this.logger.log('fetching application model...');
@@ -104,8 +102,7 @@ export default class ApplicationRoute extends Route {
 
 After:
 
-```js
-// app/services/logger.js
+```js {data-filename=app/services/logger.js}
 import Service from '@ember/service';
 
 export class Logger extends Service {
@@ -114,8 +111,7 @@ export class Logger extends Service {
   }
 }
 ```
-```js
-// app/routes/application.js
+```js {data-filename=app/routes/application.js}
 import { inject as service } from '@ember/service';
 
 export default class ApplicationRoute extends Route {
@@ -133,8 +129,7 @@ service, the value can be accessed by looking it up directly on the container
 instead using the [lookup](https://api.emberjs.com/ember/3.22/classes/ApplicationInstance/methods/lookup?anchor=lookup)
 method:
 
-```js
-// app/routes/application.js
+```js {data-filename=app/routes/application.js}
 import { getOwner } from '@ember/application';
 import { inject as service } from '@ember/service';
 

--- a/content/ember/v3/route-disconnect-outlet.md
+++ b/content/ember/v3/route-disconnect-outlet.md
@@ -11,8 +11,7 @@ The migration path is the [same as the one](https://deprecations.emberjs.com/v3.
 
 Given:
 
-```js
-// app/routes/checkout.js
+```js {data-filename=app/routes/checkout.js}
 class CheckoutRoute extends Route {
   // ...
 
@@ -48,8 +47,7 @@ class CheckoutRoute extends Route {
 
 This can transitioned to:
 
-```js
-// app/controller/checkout.js
+```js {data-filename=app/controller/checkout.js}
 class CheckoutController extends Controller {
   // ...
   @tracked isModalOpen = false;

--- a/content/ember/v3/route-render-template.md
+++ b/content/ember/v3/route-render-template.md
@@ -13,8 +13,7 @@ __Migrating Named Outlets__
 
 Given:
 
-```js
-// app/routes/checkout.js
+```js {data-filename=app/routes/checkout.js}
 class CheckoutRoute extends Route {
   // ...
   renderTemplate() {
@@ -53,8 +52,7 @@ We can migrate this entirely to use components.
 
 __Migrating Hiearchy Escaping__
 
-```js
-// app/routes/checkout.js
+```js {data-filename=app/routes/checkout.js}
 class CheckoutRoute extends Route {
   // ...
 
@@ -90,8 +88,7 @@ class CheckoutRoute extends Route {
 
 This can transitioned to:
 
-```js
-// app/controller/checkout.js
+```js {data-filename=app/controller/checkout.js}
 class CheckoutController extends Controller {
   // ...
   @tracked isModalOpen = false;

--- a/content/ember/v4/deprecate-auto-location.md
+++ b/content/ember/v4/deprecate-auto-location.md
@@ -47,8 +47,7 @@ this one is now deprecated.
 3. If you need feature detection you can run your detection code in app/router.js, 
 before setting the location type.
 
-```js
-// app/router.js
+```js {data-filename=app/router.js}
 export default class Router extends EmberRouter {
   location = (historyFeatureDetection() ? 'history' : 'hash');
   // …


### PR DESCRIPTION
We have support for file names in our code block showdown plugin, so let's use it consistently instead of using code comments.