### PR TITLE
Add parent relationship to deprecations to allow grouping in the UI, especially in the index

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,26 @@
 
 This is the app that serves https://deprecations.emberjs.com/
 
+## Linking to deprecations
+
+You can link to a specific deprecation by using the ID of the deprecation. For example, to link to the deprecation with the ID `my-old-api`, you can use the following URL:
+`https://deprecations.emberjs.com/id/my-old-api`. These URLs can be generated in advance of adding the deprecation guide, when the deprecation lands in the code.
+When adding a deprecation the filename should match the ID of the deprecation, or the `displayId` should be specified in the frontmatter.
+
 ## Adding new deprecations
 
 The [content](https://github.com/ember-learn/deprecation-app/tree/main/content/) folder contains all the deprecations that are listed by the website. To add a new deprecation, add it to the appropriate folder by creating a new file. The content of the file needs to follow a specific format for the app to work. You can see [this sample](https://raw.githubusercontent.com/ember-learn/deprecation-app/main/content/ember/v3/getting-the-each-property.md) for reference.
+
+### Frontmatter
+
+#### Grouping deprecations
+
+```markdown
+  parent: deprecation-id
+```
+
+Can be used to nest deprecations under a parent grouping for the purpose of the UI. The deprecations will still be available via the direct ID URLs.
+
 
 ## Prerequisites
 

--- a/app/components/deprecation-article.js
+++ b/app/components/deprecation-article.js
@@ -1,10 +1,19 @@
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
 export default class DeprecationArticle extends Component {
+  @tracked showChildDeprecations = false;
+
   get idForTitle() {
     return `toc_${this.args.model.title}`;
   }
 
   get idForUntil() {
     return `toc_until-${this.args.model.until}`;
+  }
+
+  @action
+  toggleChildDeprecations() {
+    this.showChildDeprecations = !this.showChildDeprecations;
   }
 }

--- a/app/models/content.js
+++ b/app/models/content.js
@@ -1,4 +1,4 @@
-import Model, { attr } from '@ember-data/model';
+import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 
 export default class ContentModel extends Model {
   @attr content;
@@ -7,6 +7,8 @@ export default class ContentModel extends Model {
   @attr since;
   @attr anchor;
   @attr displayId;
+  @belongsTo('content', { inverse: 'children', async: false }) parent;
+  @hasMany('content', { inverse: 'parent', async: false }) children;
 
   // v1 has different meta, so conditionally render it
   get renderUntil() {

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -127,6 +127,10 @@ table {
   width: 1px;
 }
 
+.hide {
+  display: none !important;
+}
+
 @media (max-width: 1007px) {
   body.no-scroll {
     overflow: hidden;

--- a/app/templates/components/deprecation-article.hbs
+++ b/app/templates/components/deprecation-article.hbs
@@ -3,9 +3,29 @@
   <div class="my-2">
     {{#if @model.renderUntil}}
       <div><span class="bold">until: </span>{{@model.until}}</div>
-      <div><span class="bold">id: </span>{{or @model.displayId @model.id}}</div>
+      <div><span class="bold">since: </span>{{@model.since}}</div>
+      <div><span class="bold">id: </span><LinkTo @route="id" @model={{@model.id}}>{{or @model.displayId @model.id}}</LinkTo></div>
+    {{/if}}
+    {{#if @model.parent}}
+      <div><span class="bold">included in: </span><LinkTo @route="id" @model={{@model.parent.id}}>{{or @model.parent.displayId @model.parent.id}}</LinkTo> </div>
+    {{/if}}
+    {{#if @model.children.length}}
+      <div><span class="bold">includes: </span> {{@model.children.length}} deprecations <button type="button" {{on "click" this.toggleChildDeprecations}}>{{(if this.showChildDeprecations 'Collapse all' 'Expand all')}}</button></div>
     {{/if}}
   </div>
+  {{#if this.showChildDeprecations}}
+    {{#each @model.children as |child|}}
+      <DeprecationArticle @model={{child}}>
+        <h3>
+          {{markdown-to-html
+            child.title
+            extensions="no-wrapper"
+            tagName=""
+          }}
+        </h3>
+      </DeprecationArticle>
+    {{/each}}
+  {{/if}}
   <section>
     {{markdown-to-html @model.content}}
   </section>

--- a/app/templates/components/deprecation-article.hbs
+++ b/app/templates/components/deprecation-article.hbs
@@ -7,26 +7,37 @@
       <div><span class="bold">id: </span><LinkTo @route="id" @model={{@model.id}}>{{or @model.displayId @model.id}}</LinkTo></div>
     {{/if}}
     {{#if @model.parent}}
-      <div><span class="bold">included in: </span><LinkTo @route="id" @model={{@model.parent.id}}>{{or @model.parent.displayId @model.parent.id}}</LinkTo> </div>
+      <div>
+        <span class="bold">included in: </span>
+        <LinkTo @route="id" @model={{@model.parent.id}}>
+          {{or @model.parent.displayId @model.parent.id}}
+        </LinkTo> 
+      </div>
     {{/if}}
     {{#if @model.children.length}}
-      <div><span class="bold">includes: </span> {{@model.children.length}} deprecations <button type="button" {{on "click" this.toggleChildDeprecations}}>{{(if this.showChildDeprecations 'Collapse all' 'Expand all')}}</button></div>
+      <div>
+        <span class="bold">includes: </span> {{@model.children.length}} deprecations 
+        <button type="button" {{on "click" this.toggleChildDeprecations}}>
+          {{(if this.showChildDeprecations 'Collapse all' 'Expand all')}}
+        </button>
+      </div>
     {{/if}}
   </div>
-  {{#if this.showChildDeprecations}}
-    {{#each @model.children as |child|}}
-      <DeprecationArticle @model={{child}}>
-        <h3>
-          {{markdown-to-html
-            child.title
-            extensions="no-wrapper"
-            tagName=""
-          }}
-        </h3>
-      </DeprecationArticle>
-    {{/each}}
-  {{/if}}
   <section>
     {{markdown-to-html @model.content}}
+    {{#if this.showChildDeprecations}}
+      {{#each @model.children as |child|}}
+        <DeprecationArticle @model={{child}}>
+          <hr>
+          <h3>
+            {{markdown-to-html
+              child.title
+              extensions="no-wrapper"
+              tagName=""
+            }}
+          </h3>
+        </DeprecationArticle>
+      {{/each}}
+    {{/if}}
   </section>
 </div>

--- a/app/templates/components/deprecation-article.hbs
+++ b/app/templates/components/deprecation-article.hbs
@@ -11,12 +11,12 @@
         <span class="bold">included in: </span>
         <LinkTo @route="id" @model={{@model.parent.id}}>
           {{or @model.parent.displayId @model.parent.id}}
-        </LinkTo> 
+        </LinkTo>
       </div>
     {{/if}}
     {{#if @model.children.length}}
       <div>
-        <span class="bold">includes: </span> {{@model.children.length}} deprecations 
+        <span class="bold">includes: </span> {{@model.children.length}} deprecations
         <button type="button" {{on "click" this.toggleChildDeprecations}}>
           {{(if this.showChildDeprecations 'Collapse all' 'Expand all')}}
         </button>
@@ -25,7 +25,7 @@
   </div>
   <section>
     {{markdown-to-html @model.content}}
-    {{#if this.showChildDeprecations}}
+    <div class="{{unless this.showChildDeprecations 'hide'}}">
       {{#each @model.children as |child|}}
         <DeprecationArticle @model={{child}}>
           <hr>
@@ -38,6 +38,6 @@
           </h3>
         </DeprecationArticle>
       {{/each}}
-    {{/if}}
+    </div>
   </section>
 </div>

--- a/app/utils/process-results.js
+++ b/app/utils/process-results.js
@@ -5,6 +5,9 @@ const GLIMMER = 'Glimmer Internals';
 
 export default function processResults(query) {
   let results = query.toArray().reduce((results, item) => {
+    if (item.parent) {
+      return results;
+    }
     let since = results.find((result) => result.since === item.since);
     if (!since) {
       since = { since: item.since, contents: [] };

--- a/content/ember/v6/deprecate-import---loader-from-ember.md
+++ b/content/ember/v6/deprecate-import---loader-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.__loader
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import--action-from-ember.md
+++ b/content/ember/v6/deprecate-import--action-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember._action
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import--array-from-ember.md
+++ b/content/ember/v6/deprecate-import--array-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember._array
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import--assert-destroyables-destroyed-from-ember.md
+++ b/content/ember/v6/deprecate-import--assert-destroyables-destroyed-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember._assertDestroyablesDestroyed
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import--associate-destroyable-child-from-ember.md
+++ b/content/ember/v6/deprecate-import--associate-destroyable-child-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember._associateDestroyableChild
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import--backburner-from-ember.md
+++ b/content/ember/v6/deprecate-import--backburner-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember._Backburner
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import--cache-from-ember.md
+++ b/content/ember/v6/deprecate-import--cache-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember._Cache
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import--cache-get-value-from-ember.md
+++ b/content/ember/v6/deprecate-import--cache-get-value-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember._cacheGetValue
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import--cache-is-const-from-ember.md
+++ b/content/ember/v6/deprecate-import--cache-is-const-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember._cacheIsConst
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import--capture-render-tree-from-ember.md
+++ b/content/ember/v6/deprecate-import--capture-render-tree-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember._captureRenderTree
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import--component-manager-capabilities-from-ember.md
+++ b/content/ember/v6/deprecate-import--component-manager-capabilities-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember._componentManagerCapabilities
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import--concat-from-ember.md
+++ b/content/ember/v6/deprecate-import--concat-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember._concat
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import--container-proxy-mixin-from-ember.md
+++ b/content/ember/v6/deprecate-import--container-proxy-mixin-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember._ContainerProxyMixin
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import--create-cache-from-ember.md
+++ b/content/ember/v6/deprecate-import--create-cache-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember._createCache
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import--dependent-key-compat-from-ember.md
+++ b/content/ember/v6/deprecate-import--dependent-key-compat-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember._dependentKeyCompat
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import--descriptor-from-ember.md
+++ b/content/ember/v6/deprecate-import--descriptor-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember._descriptor
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import--enable-destroyable-tracking-from-ember.md
+++ b/content/ember/v6/deprecate-import--enable-destroyable-tracking-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember._enableDestroyableTracking
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import--fn-from-ember.md
+++ b/content/ember/v6/deprecate-import--fn-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember._fn
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import--get-component-template-from-ember.md
+++ b/content/ember/v6/deprecate-import--get-component-template-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember._getComponentTemplate
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import--get-from-ember.md
+++ b/content/ember/v6/deprecate-import--get-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember._get
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import--get-path-from-ember.md
+++ b/content/ember/v6/deprecate-import--get-path-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember._getPath
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import--hash-from-ember.md
+++ b/content/ember/v6/deprecate-import--hash-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember._hash
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import--helper-manager-capabilities-from-ember.md
+++ b/content/ember/v6/deprecate-import--helper-manager-capabilities-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember._helperManagerCapabilities
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import--input-from-ember.md
+++ b/content/ember/v6/deprecate-import--input-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember._Input
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import--invoke-helper-from-ember.md
+++ b/content/ember/v6/deprecate-import--invoke-helper-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember._invokeHelper
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import--is-destroyed-from-ember.md
+++ b/content/ember/v6/deprecate-import--is-destroyed-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember._isDestroyed
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import--is-destroying-from-ember.md
+++ b/content/ember/v6/deprecate-import--is-destroying-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember._isDestroying
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import--modifier-manager-capabilities-from-ember.md
+++ b/content/ember/v6/deprecate-import--modifier-manager-capabilities-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember._modifierManagerCapabilities
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import--on-from-ember.md
+++ b/content/ember/v6/deprecate-import--on-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember._on
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import--proxy-mixin-from-ember.md
+++ b/content/ember/v6/deprecate-import--proxy-mixin-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember._ProxyMixin
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import--register-destructor-from-ember.md
+++ b/content/ember/v6/deprecate-import--register-destructor-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember._registerDestructor
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import--registry-proxy-mixin-from-ember.md
+++ b/content/ember/v6/deprecate-import--registry-proxy-mixin-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember._RegistryProxyMixin
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import--set-classic-decorator-from-ember.md
+++ b/content/ember/v6/deprecate-import--set-classic-decorator-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember._setClassicDecorator
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import--set-component-manager-from-ember.md
+++ b/content/ember/v6/deprecate-import--set-component-manager-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember._setComponentManager
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import--set-component-template-from-ember.md
+++ b/content/ember/v6/deprecate-import--set-component-template-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember._setComponentTemplate
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import--set-helper-manager-from-ember.md
+++ b/content/ember/v6/deprecate-import--set-helper-manager-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember._setHelperManager
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import--set-modifier-manager-from-ember.md
+++ b/content/ember/v6/deprecate-import--set-modifier-manager-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember._setModifierManager
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import--template-only-component-from-ember.md
+++ b/content/ember/v6/deprecate-import--template-only-component-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember._templateOnlyComponent
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import--tracked-from-ember.md
+++ b/content/ember/v6/deprecate-import--tracked-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember._tracked
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import--unregister-destructor-from-ember.md
+++ b/content/ember/v6/deprecate-import--unregister-destructor-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember._unregisterDestructor
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-a-from-ember.md
+++ b/content/ember/v6/deprecate-import-a-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.A
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-action-handler-from-ember.md
+++ b/content/ember/v6/deprecate-import-action-handler-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.ActionHandler
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-add-listener-from-ember.md
+++ b/content/ember/v6/deprecate-import-add-listener-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.addListener
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-add-observer-from-ember.md
+++ b/content/ember/v6/deprecate-import-add-observer-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.addObserver
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-application-from-ember.md
+++ b/content/ember/v6/deprecate-import-application-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.Application
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-application-instance-from-ember.md
+++ b/content/ember/v6/deprecate-import-application-instance-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.ApplicationInstance
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-array-from-ember.md
+++ b/content/ember/v6/deprecate-import-array-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.Array
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-array-proxy-from-ember.md
+++ b/content/ember/v6/deprecate-import-array-proxy-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.ArrayProxy
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-assert-from-ember.md
+++ b/content/ember/v6/deprecate-import-assert-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.assert
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-begin-property-changes-from-ember.md
+++ b/content/ember/v6/deprecate-import-begin-property-changes-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.beginPropertyChanges
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-booted-from-ember.md
+++ b/content/ember/v6/deprecate-import-booted-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.BOOTED
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-cache-for-from-ember.md
+++ b/content/ember/v6/deprecate-import-cache-for-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.cacheFor
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-can-invoke-from-ember.md
+++ b/content/ember/v6/deprecate-import-can-invoke-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.canInvoke
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-change-properties-from-ember.md
+++ b/content/ember/v6/deprecate-import-change-properties-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.changeProperties
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-comparable-from-ember.md
+++ b/content/ember/v6/deprecate-import-comparable-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.Comparable
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-compare-from-ember.md
+++ b/content/ember/v6/deprecate-import-compare-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.compare
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-component-from-ember.md
+++ b/content/ember/v6/deprecate-import-component-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.Component
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-computed-from-ember.md
+++ b/content/ember/v6/deprecate-import-computed-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.computed
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-computed-property-from-ember.md
+++ b/content/ember/v6/deprecate-import-computed-property-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.ComputedProperty
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-container-debug-adapter-from-ember.md
+++ b/content/ember/v6/deprecate-import-container-debug-adapter-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.ContainerDebugAdapter
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-container-from-ember.md
+++ b/content/ember/v6/deprecate-import-container-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.Container
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-controller-for-from-ember.md
+++ b/content/ember/v6/deprecate-import-controller-for-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.controllerFor
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-controller-from-ember.md
+++ b/content/ember/v6/deprecate-import-controller-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.Controller
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-controller-mixin-from-ember.md
+++ b/content/ember/v6/deprecate-import-controller-mixin-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.ControllerMixin
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-core-object-from-ember.md
+++ b/content/ember/v6/deprecate-import-core-object-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.CoreObject
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-data-adapter-from-ember.md
+++ b/content/ember/v6/deprecate-import-data-adapter-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.DataAdapter
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-debug-from-ember.md
+++ b/content/ember/v6/deprecate-import-debug-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.debug
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-define-property-from-ember.md
+++ b/content/ember/v6/deprecate-import-define-property-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.defineProperty
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-deprecate-from-ember.md
+++ b/content/ember/v6/deprecate-import-deprecate-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.deprecate
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-deprecate-func-from-ember.md
+++ b/content/ember/v6/deprecate-import-deprecate-func-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.deprecateFunc
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-destroy-from-ember.md
+++ b/content/ember/v6/deprecate-import-destroy-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.destroy
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-ember-from-ember.md
+++ b/content/ember/v6/deprecate-import-ember-from-ember.md
@@ -1,0 +1,10 @@
+---
+title: import Ember from 'ember'
+until: 7.0.0
+since: 6.5.0
+---
+
+`import Ember from 'ember';` is deprecated. APIs that were previously accessed 
+via `Ember` should be imported directly from their respective packages.
+
+This was introduced in [RFC #1003](https://rfcs.emberjs.com/id/1003-deprecation-import-ember-from-ember).

--- a/content/ember/v6/deprecate-import-end-property-changes-from-ember.md
+++ b/content/ember/v6/deprecate-import-end-property-changes-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.endPropertyChanges
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-engine-from-ember.md
+++ b/content/ember/v6/deprecate-import-engine-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.Engine
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-engine-instance-from-ember.md
+++ b/content/ember/v6/deprecate-import-engine-instance-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.EngineInstance
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-enumerable-from-ember.md
+++ b/content/ember/v6/deprecate-import-enumerable-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.Enumerable
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-env-from-ember.md
+++ b/content/ember/v6/deprecate-import-env-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.ENV
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-evented-from-ember.md
+++ b/content/ember/v6/deprecate-import-evented-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.Evented
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-expand-properties-from-ember.md
+++ b/content/ember/v6/deprecate-import-expand-properties-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.expandProperties
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-features-from-ember.md
+++ b/content/ember/v6/deprecate-import-features-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.FEATURES
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-generate-controller-factory-from-ember.md
+++ b/content/ember/v6/deprecate-import-generate-controller-factory-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.generateControllerFactory
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-generate-controller-from-ember.md
+++ b/content/ember/v6/deprecate-import-generate-controller-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.generateController
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-generate-guid-from-ember.md
+++ b/content/ember/v6/deprecate-import-generate-guid-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.generateGuid
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-get-from-ember.md
+++ b/content/ember/v6/deprecate-import-get-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.get
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-get-owner-from-ember.md
+++ b/content/ember/v6/deprecate-import-get-owner-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.getOwner
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-get-properties-from-ember.md
+++ b/content/ember/v6/deprecate-import-get-properties-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.getProperties
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-guid-for-from-ember.md
+++ b/content/ember/v6/deprecate-import-guid-for-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.guidFor
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-guid-key-from-ember.md
+++ b/content/ember/v6/deprecate-import-guid-key-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.GUID_KEY
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-handlebars-from-ember.md
+++ b/content/ember/v6/deprecate-import-handlebars-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.Handlebars
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-has-listeners-from-ember.md
+++ b/content/ember/v6/deprecate-import-has-listeners-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.hasListeners
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-hash-location-from-ember.md
+++ b/content/ember/v6/deprecate-import-hash-location-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.HashLocation
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-helper-from-ember.md
+++ b/content/ember/v6/deprecate-import-helper-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.Helper
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-history-location-from-ember.md
+++ b/content/ember/v6/deprecate-import-history-location-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.HistoryLocation
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-htmlbars-from-ember.md
+++ b/content/ember/v6/deprecate-import-htmlbars-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.HTMLBars
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-inject-from-ember.md
+++ b/content/ember/v6/deprecate-import-inject-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.inject
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-inspect-from-ember.md
+++ b/content/ember/v6/deprecate-import-inspect-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.inspect
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-instrument-from-ember.md
+++ b/content/ember/v6/deprecate-import-instrument-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.instrument
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-instrumentation-from-ember.md
+++ b/content/ember/v6/deprecate-import-instrumentation-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.Instrumentation
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-is-array-from-ember.md
+++ b/content/ember/v6/deprecate-import-is-array-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.isArray
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-is-blank-from-ember.md
+++ b/content/ember/v6/deprecate-import-is-blank-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.isBlank
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-is-empty-from-ember.md
+++ b/content/ember/v6/deprecate-import-is-empty-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.isEmpty
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-is-equal-from-ember.md
+++ b/content/ember/v6/deprecate-import-is-equal-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.isEqual
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-is-namespace-from-ember.md
+++ b/content/ember/v6/deprecate-import-is-namespace-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.isNamespace
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-is-present-from-ember.md
+++ b/content/ember/v6/deprecate-import-is-present-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.isPresent
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-libraries-from-ember.md
+++ b/content/ember/v6/deprecate-import-libraries-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.libraries
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-lookup-from-ember.md
+++ b/content/ember/v6/deprecate-import-lookup-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.lookup
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-make-array-from-ember.md
+++ b/content/ember/v6/deprecate-import-make-array-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.makeArray
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-meta-from-ember.md
+++ b/content/ember/v6/deprecate-import-meta-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.meta
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-mixin-from-ember.md
+++ b/content/ember/v6/deprecate-import-mixin-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.mixin
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-mutable-array-from-ember.md
+++ b/content/ember/v6/deprecate-import-mutable-array-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.MutableArray
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-mutable-enumerable-from-ember.md
+++ b/content/ember/v6/deprecate-import-mutable-enumerable-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.MutableEnumerable
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-namespace-from-ember.md
+++ b/content/ember/v6/deprecate-import-namespace-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.Namespace
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-native-array-from-ember.md
+++ b/content/ember/v6/deprecate-import-native-array-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.NativeArray
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-none-location-from-ember.md
+++ b/content/ember/v6/deprecate-import-none-location-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.NoneLocation
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-notify-property-change-from-ember.md
+++ b/content/ember/v6/deprecate-import-notify-property-change-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.notifyPropertyChange
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-object-from-ember.md
+++ b/content/ember/v6/deprecate-import-object-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.Object
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-object-proxy-from-ember.md
+++ b/content/ember/v6/deprecate-import-object-proxy-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.ObjectProxy
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-observable-from-ember.md
+++ b/content/ember/v6/deprecate-import-observable-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.Observable
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-observer-from-ember.md
+++ b/content/ember/v6/deprecate-import-observer-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.observer
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-on-from-ember.md
+++ b/content/ember/v6/deprecate-import-on-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.on
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-on-load-from-ember.md
+++ b/content/ember/v6/deprecate-import-on-load-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.onLoad
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-onerror-from-ember.md
+++ b/content/ember/v6/deprecate-import-onerror-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.onerror
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-promise-proxy-mixin-from-ember.md
+++ b/content/ember/v6/deprecate-import-promise-proxy-mixin-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.PromiseProxyMixin
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-registry-from-ember.md
+++ b/content/ember/v6/deprecate-import-registry-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.Registry
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-remove-listener-from-ember.md
+++ b/content/ember/v6/deprecate-import-remove-listener-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.removeListener
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-remove-observer-from-ember.md
+++ b/content/ember/v6/deprecate-import-remove-observer-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.removeObserver
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-route-from-ember.md
+++ b/content/ember/v6/deprecate-import-route-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.Route
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-router-dsl-from-ember.md
+++ b/content/ember/v6/deprecate-import-router-dsl-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.RouterDSL
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-rsvp-from-ember.md
+++ b/content/ember/v6/deprecate-import-rsvp-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.RSVP
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-run-from-ember.md
+++ b/content/ember/v6/deprecate-import-run-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.run
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-run-in-debug-from-ember.md
+++ b/content/ember/v6/deprecate-import-run-in-debug-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.runInDebug
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-run-load-hooks-from-ember.md
+++ b/content/ember/v6/deprecate-import-run-load-hooks-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.runLoadHooks
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-send-event-from-ember.md
+++ b/content/ember/v6/deprecate-import-send-event-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.sendEvent
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-service-from-ember.md
+++ b/content/ember/v6/deprecate-import-service-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.Service
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-set-from-ember.md
+++ b/content/ember/v6/deprecate-import-set-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.set
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-set-owner-from-ember.md
+++ b/content/ember/v6/deprecate-import-set-owner-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.setOwner
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-set-properties-from-ember.md
+++ b/content/ember/v6/deprecate-import-set-properties-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.setProperties
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-setup-for-testing-from-ember.md
+++ b/content/ember/v6/deprecate-import-setup-for-testing-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.setupForTesting
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-subscribe-from-ember.md
+++ b/content/ember/v6/deprecate-import-subscribe-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.subscribe
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-templates-from-ember.md
+++ b/content/ember/v6/deprecate-import-templates-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.TEMPLATES
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-test-from-ember.md
+++ b/content/ember/v6/deprecate-import-test-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.Test
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-testing-from-ember.md
+++ b/content/ember/v6/deprecate-import-testing-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.testing
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-to-string-from-ember.md
+++ b/content/ember/v6/deprecate-import-to-string-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.toString
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-try-set-from-ember.md
+++ b/content/ember/v6/deprecate-import-try-set-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.trySet
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-type-of-from-ember.md
+++ b/content/ember/v6/deprecate-import-type-of-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.typeOf
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-uuid-from-ember.md
+++ b/content/ember/v6/deprecate-import-uuid-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.uuid
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-version-from-ember.md
+++ b/content/ember/v6/deprecate-import-version-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.VERSION
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-view-utils-from-ember.md
+++ b/content/ember/v6/deprecate-import-view-utils-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.ViewUtils
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-warn-from-ember.md
+++ b/content/ember/v6/deprecate-import-warn-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.warn
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/content/ember/v6/deprecate-import-wrap-from-ember.md
+++ b/content/ember/v6/deprecate-import-wrap-from-ember.md
@@ -2,6 +2,7 @@
 title: Ember.wrap
 until: 7.0.0
 since: 6.5.0
+parent: deprecate-import-ember-from-ember
 ---
 
 

--- a/lib/content-docs-generator/index.js
+++ b/lib/content-docs-generator/index.js
@@ -26,6 +26,7 @@ const jsonTrees = contentFolders.map(
   (type) =>
     new StaticSiteJson(`content/${type}`, {
       attributes: ['title', 'since', 'until', 'anchor', 'displayId'],
+      references: [{ name: 'parent', type: 'content' }],
       type: 'contents',
       collate: true,
       collationFileName: `${type.replace(/\//, '-')}.x.json`,


### PR DESCRIPTION
- Added `since` to the metadata display since I felt it was missing especially on the id route
- Made id in the metadata display link to the individual id page to expose those URLs
- Added some info to the README about the new relationship but also about adding deprecation guides

No deprecations currently use this, though I did certainly test it out. I am aiming to use this for #1381 so we do not lose the usefulness of the index. Due to the way the `Deprecate `import Ember from 'ember'`` deprecation is done, we need a URL for every single API even if they weren't ones that were at all used by the public. I don't want the index to scare people off of upgrading to 6.0, but there should still be a way to see all the related deprecations.

cc @NullVoxPopuli 

![CleanShot 2025-04-04 at 17 14 03](https://github.com/user-attachments/assets/73c1b7c0-c2ce-4105-8c20-822fabf4b29d)
