### PR TITLE
refactor: use data diff in md

### DIFF
--- a/content/ember-cli/v4/ember-cli-blacklist-whitelist-build-options.md
+++ b/content/ember-cli/v4/ember-cli-blacklist-whitelist-build-options.md
@@ -9,14 +9,12 @@ displayId: ember-cli.blacklist-whitelist-build-options
 Using the `blacklist` and `whitelist` build options has been deprecated. Please 
 use `exclude` and `include` respectively instead.
 
-```diff
-// ember-cli-build.js
-
+```js {data-filename="ember-cli-build.js" data-diff="-4,+5"}
 module.exports = function (defaults) {
   const app = new EmberApp(defaults, {
     addons: {
--     blacklist: ['addon-name'],
-+     exclude: ['addon-name'],
+      blacklist: ['addon-name'],
+      exclude: ['addon-name'],
     },
   };
 };

--- a/content/ember-cli/v5/ember-cli-output-paths-build-option.md
+++ b/content/ember-cli/v5/ember-cli-output-paths-build-option.md
@@ -10,21 +10,21 @@ Using the `outputPaths` build option is deprecated, as output paths will no long
 
 To resolve the deprecation, please remove the `outputPaths` build option from your `ember-cli-build.js` file:
 
-```diff
+```js {data-diff="-3,-4,-5,-6,-7"}
 module.exports = function (defaults) {
   const app = new EmberApp(defaults, {
--   outputPaths: {
--     app: {
--       js: `/assets/foo.js`,
--     },
--   },
+    outputPaths: {
+      app: {
+        js: `/assets/foo.js`,
+      },
+    },
   };
 };
 ```
 
 And update your `app/index.html` file accordingly:
 
-```diff
+```html {data-diff="-20,+21"}
 <!DOCTYPE html>
 <html>
   <head>
@@ -44,8 +44,8 @@ And update your `app/index.html` file accordingly:
     {{content-for "body"}}
 
     <script src="{{rootURL}}assets/vendor.js"></script>
--   <script src="{{rootURL}}assets/foo.js"></script>
-+   <script src="{{rootURL}}assets/my-app-name.js"></script>
+    <script src="{{rootURL}}assets/foo.js"></script>
+    <script src="{{rootURL}}assets/my-app-name.js"></script>
 
     {{content-for "body-footer"}}
   </body>

--- a/content/ember-data/v4/ember-data-deprecate-string-arg-schemas.md
+++ b/content/ember-data/v4/ember-data-deprecate-string-arg-schemas.md
@@ -9,7 +9,7 @@ Deprecates `schema.attributesDefinitionFor(type)` and `schema.relationshipsDefin
 
 To resolve change:
 
-```diff
-- store.getSchemaDefinitionService().attributesDefinitionFor('user')
-+ store.getSchemaDefinitionService().attributesDefinitionFor({ type: 'user' })
+```js {data-diff="-1,+2"}
+store.getSchemaDefinitionService().attributesDefinitionFor('user')
+store.getSchemaDefinitionService().attributesDefinitionFor({ type: 'user' })
 ```


### PR DESCRIPTION
This PR refactors markdown code fences with the `diff` language to use the native `data-diff` functionality of the code renderer. The benefit is that syntax highlighting gets added.