### PR TITLE
Mobile list styling

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -586,7 +586,9 @@ p a:hover {
         .ember-version-graphic {
           $height: 132px;
           width: $height;
-          height: $height;
+          min-height: $height;
+          height: inherit;
+          background-position-y: center;
 
           .text {
             font-size: 64px;


### PR DESCRIPTION
To fix #1239 . I decided for a simpler approach than #1240 
<img width="480" alt="Screenshot 2024-07-23 at 11 55 52" src="https://github.com/user-attachments/assets/cfcb1399-9c08-4148-bc38-bb404dac0ba7">

closes: https://github.com/ember-learn/deprecation-app/pull/1240
