### PR TITLE
Updating enabled release for importing-inject-from-ember-service

### DIFF
--- a/content/ember/v6/importing-inject-from-ember-service.md
+++ b/content/ember/v6/importing-inject-from-ember-service.md
@@ -1,7 +1,7 @@
 ---
 title: Importing `inject` from `@ember/service`
 until: 7.0.0
-since: 6.2.0
+since: 6.3.0
 ---
 
 Importing `inject` from `@ember/service` is deprecated. Please import `service` instead.


### PR DESCRIPTION
This will be enabled in ember 6.3.0.

https://github.com/emberjs/ember.js/pull/20820