### PR TITLE
fix: width issue when no code block

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -207,6 +207,18 @@ table {
   }
 }
 
+@media (min-width: 1007px) and (max-width: 1261px) {
+  .layout-grid {
+    grid-template:
+      "sidebar main" auto /
+      20rem 1fr;
+  }
+  
+  .main {
+    width: auto;
+  }
+}
+
 @media (min-width: 1007px) {
   .toc-toggle {
     display: none;

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -56,7 +56,7 @@ table {
 // override ember-styleguide. Needed to contain code blocks.
 .main {
   grid-area: main;
-  max-width: 700px;
+  width: 700px;
 }
 
 // override ember-styleguide. Looks like normal text otherwise.
@@ -152,7 +152,7 @@ table {
     grid-area: main;
     overflow: auto;
     margin-left: 0;
-    max-width: 100%;
+    width: 100%;
   }
 
   .padding-vertical-small {


### PR DESCRIPTION
Before: 
![image](https://github.com/user-attachments/assets/a2cf92de-8237-4bf0-b14f-3833f87453fc)


after: 
![image](https://github.com/user-attachments/assets/71b73612-85c7-4b88-a68d-9de3da7ff766)
