### PR TITLE
update the since value on embroider deprecation

### DIFF
--- a/content/ember-cli/v6/dont-use-embroider-option.md
+++ b/content/ember-cli/v6/dont-use-embroider-option.md
@@ -1,6 +1,6 @@
 ---
 title: Don't use `--embroider` option for `ember init` or `ember new`
-since: 6.7.0
+since: 6.8.0
 until: 7.0.0
 ---
 


### PR DESCRIPTION
current master of ember-cli is 6.8 so that will be the first version that will have this deprecation 👍 