### PR TITLE
ember-cli: Deprecate `init` with file names or globs

### DIFF
--- a/content/ember-cli/v6/init-no-file-names.md
+++ b/content/ember-cli/v6/init-no-file-names.md
@@ -1,0 +1,13 @@
+---
+title: '`init` with file names or globs'
+since: 6.8.0
+until: 7.0.0
+---
+
+Using `ember init package.json` or `ember init app/**` was once added to generate specific files or file structures from the app blueprint. Globbing doesn't work at all anymore and you need to know the specific filename within the classic app blueprint to use this.
+
+This feature was never documented in the `--help` output, but if you find yourself in a situation where you want to re-`init` a specific file for your app, do this instead:
+
+1. Verify that you start with a clean git working tree; otherwise stash or commit any pending changes
+2. Run the `ember init` command as usual
+3. Use git to remove the files you didn't want to regenerate


### PR DESCRIPTION
- does not work as intended
- does not work as tested
- inconclusive tests mask the broken behavior
- completely undocumented

Implementation: https://github.com/ember-cli/ember-cli/pull/10785

---

This work is supported by the [Mainmatter Ember Initiative](https://mainmatter.com/ember-initiative/).